### PR TITLE
Fix typos

### DIFF
--- a/monkeytype/config.py
+++ b/monkeytype/config.py
@@ -32,7 +32,7 @@ from monkeytype.typing import (
 
 
 class Config(metaclass=ABCMeta):
-    """A Config ties together concrete implementations of the diffrent abstractions
+    """A Config ties together concrete implementations of the different abstractions
     that make up a typical deployment of MonkeyType.
     """
     @abstractmethod

--- a/monkeytype/encoding.py
+++ b/monkeytype/encoding.py
@@ -97,7 +97,7 @@ def type_from_dict(d: TypeDict) -> type:
     elem_type_dicts = d.get('elem_types')
     if elem_type_dicts and isinstance(typ, (_Union, GenericMeta)):
         elem_types = tuple(type_from_dict(e) for e in elem_type_dicts)
-        # mypy compains that a value of type `type` isn't indexable. That's
+        # mypy complains that a value of type `type` isn't indexable. That's
         # true, but we know typ is a subtype that is indexable. Even checking
         # with hasattr(typ, '__getitem__') doesn't help
         typ = typ[elem_types]  # type: ignore

--- a/monkeytype/tracing.py
+++ b/monkeytype/tracing.py
@@ -47,7 +47,7 @@ class CallTrace:
     ) -> None:
         """
         Args:
-            func: The function where the trace ocurred
+            func: The function where the trace occurred
             arg_types: The collected argument types
             return_type: The collected return type. This will be None if the called function returns
                 due to an unhandled exception. It will be NoneType if the function returns the value None.

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -218,7 +218,7 @@ class TestFunctionStub:
         assert stub.render() == expected
 
     def test_split_parameters_across_multiple_lines(self):
-        """When single-line length exceeds 120 characters, parameters should be splitted into multiple lines."""
+        """When single-line length exceeds 120 characters, parameters should be split into multiple lines."""
         stub = FunctionStub('has_length_exceeds_120_chars',
                             inspect.signature(has_length_exceeds_120_chars),
                             FunctionKind.MODULE)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,11 +33,11 @@ class TestGetNameInModule:
         obj = get_name_in_module(Outer.__module__, Outer.Inner.f.__qualname__)
         assert obj == Outer.Inner.f
 
-    def test_get_nonexistant_module(self):
+    def test_get_nonexistent_module(self):
         with pytest.raises(NameLookupError):
             get_name_in_module('xxx.dontexist', 'foo')
 
-    def test_get_nonexistant_qualname(self):
+    def test_get_nonexistent_qualname(self):
         with pytest.raises(NameLookupError):
             get_name_in_module(
                 a_module_func.__module__, 'Outer.xxx_i_dont_exist_xxx')
@@ -45,7 +45,7 @@ class TestGetNameInModule:
 
 class TestGetFuncInModule:
     def test_get_method(self):
-        """Make sure we return the underyling function for boundmethods"""
+        """Make sure we return the underlying function for boundmethods"""
         meth = Dummy.a_class_method
         obj = get_func_in_module(meth.__module__, meth.__qualname__)
         assert obj == meth.__func__


### PR DESCRIPTION
old | new
--- | ---
 `diffrent` | `different`
 `compains` | `complains`
 `ocurred` | `occurred`
 `splitted` | `split`
 `nonexistant` | `nonexistent`
 `underyling` | `underlying`