### PR TITLE
Support passing arguments to scripts (fixes #18)

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -195,6 +195,10 @@ def main(argv: List[str], stdout: IO, stderr: IO) -> int:
         'script_path',
         type=str,
         help="""Filesystem path to a Python script file to run under tracing""")
+    run_parser.add_argument(
+        'script_args',
+        nargs=argparse.REMAINDER,
+    )
     run_parser.set_defaults(handler=run_handler)
 
     apply_parser = subparsers.add_parser(


### PR DESCRIPTION
This turned out to be an easier PR than I expected. run_handler/run_path already use sys.argv directly; I just added a catchall argument to the argparser so it doesn't complain about additional tokens.

Doesn't look like there are tests for this in test_cli.py, but let me know if I should create a new one.