### PR TITLE
Generate annotations for NewType types (fixes #22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ htmlcov/
 doc/_build
 dist/
 build/
+.idea/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ master
 ------
 
 * Fix passing args to script run with ``monkeytype run`` (#18; merge of #21).
-
+* Fix generated annotations for NewType types (#22; merge of #23).
 
 17.12.1
 -------

--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -319,6 +319,8 @@ def render_annotation(anno: Any) -> str:
         elem_type = _get_optional_elem(anno)
         rendered = render_annotation(elem_type)
         return 'Optional[' + rendered + ']'
+    elif hasattr(anno, '__supertype__'):
+        return anno.__name__
     elif getattr(anno, '__module__', None) == 'typing':
         return repr(anno).replace('typing.', '')
     elif anno is NoneType:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -11,6 +11,7 @@ from typing import (
     Generator,
     Iterator,
     List,
+    NewType,
     Optional,
     Set,
     Tuple,
@@ -41,6 +42,8 @@ from monkeytype.stubs import (
 from monkeytype.tracing import CallTrace
 from monkeytype.typing import NoneType
 from .util import Dummy
+
+UserId = NewType('UserId', int)
 
 
 class TestImportMap:
@@ -131,6 +134,10 @@ def has_length_exceeds_120_chars(
     very_long_name_parameter_2: float
 ) -> Optional[float]:
     return None
+
+
+def has_newtype_param(user_id: UserId) -> None:
+    pass
 
 
 class TestHasUnparsableDefaults:
@@ -239,6 +246,11 @@ class TestFunctionStub:
     def test_default_none_parameter_annotation(self):
         stub = FunctionStub('test', inspect.signature(default_none_parameter), FunctionKind.MODULE)
         expected = 'def test(x: Optional[int] = None) -> None: ...'
+        assert stub.render() == expected
+
+    def test_newtype_parameter_annotation(self):
+        stub = FunctionStub('test', inspect.signature(has_newtype_param), FunctionKind.MODULE)
+        expected = 'def test(user_id: UserId) -> None: ...'
         assert stub.render() == expected
 
 


### PR DESCRIPTION
Per #22, monkeytype generates invalid type signatures for NewType types because they are valid mypy annotations but `new_type()` gets inspected as a function at runtime. This PR special-cases support for objects with `__supertype__` to return their `__name__` instead of their repr, based on https://github.com/python/cpython/blob/v3.6.3/Lib/typing.py#L2227

Since a comment says `render_annotation` was derived from `inspect.formatannotation`, I'll point out that this PR causes render_annotation to disagree with inspect.formatannotation. I think this is okay in theory since render_annotation is used for mypy types while formatannotation is used for runtime inspection, but I'd appreciate a second opinion. For what it's worth, this patch allowed me to use monkeytype against my NewType-using codebase successfully.

This seems important enough to warrant tests - if you think this PR is taking a good approach, I can write tests for it as well.