### PR TITLE
Exclude frozen importlib functions in default code filter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+* Exclude "frozen importlib" functions in default code filter.
 * Fix passing args to script run with ``monkeytype run`` (#18; merge of #21).
 
 

--- a/monkeytype/config.py
+++ b/monkeytype/config.py
@@ -85,6 +85,8 @@ if venv_real_prefix:
     lib_paths.add(
         sysconfig.get_path('stdlib', vars={'installed_base': venv_real_prefix})
     )
+# exclude code objects from frozen importlib, which have a bogus co_filename
+lib_paths.add('<frozen importlib.')
 LIB_PATHS = tuple(p for p in lib_paths if p is not None)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
+import _frozen_importlib
 import sysconfig
 
 import pytest
@@ -20,3 +21,6 @@ class TestDefaultCodeFilter:
 
     def test_includes_otherwise(self):
         assert config.default_code_filter(config.default_code_filter.__code__)
+
+    def test_excludes_frozen_importlib(self):
+        assert not config.default_code_filter(_frozen_importlib.spec_from_loader.__code__)


### PR DESCRIPTION
Just to reduce noise in the call trace store.