### PR TITLE
Add Config.cli_context() as a hook for custom CLI initialization and cleanup logic.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,6 @@ Changelog
 master
 ------
 
-
 17.12.2
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 master
 ------
 
-* Add setup/teardown CLI lifecycle hooks.
+* Add Config.cli_context() as a hook for custom CLI initialization and cleanup logic (#28; merge of #29).
 
 17.12.2
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 master
 ------
 
+* Add setup/teardown CLI lifecycle hooks.
+
 17.12.2
 -------
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -99,6 +99,32 @@ Subclassing ``Config`` or ``DefaultConfig``
 
     Defaults to ``False``.
 
+  .. method:: cli_setup(command: str) -> None
+
+    A lifecycle hook which gets called once, right after the CLI starts. Use it
+    to perform any initialization required by your codebase.
+
+    ``command`` is the command passed to the ``monkeytype`` cli: ``'run'``,
+    ``'apply'``, etc.
+
+    For example, if you run MonkeyType against a Django codebase, you can use
+    this hook to call::
+
+      import django
+      django.setup()
+
+    The default implementation of this method does nothing.
+
+  .. method:: cli_teardown(command: str) -> None
+
+    A lifecycle hook which gets called once, right before the CLI exits. Use it
+    to undo side effects from :meth:`cli_setup`, if applicable.
+
+    ``command`` is the command passed to the ``monkeytype`` cli: ``'run'``,
+    ``'apply'``, etc.
+
+    The default implementation of this method does nothing.
+
 .. class:: DefaultConfig()
 
   ``DefaultConfig`` is the config MonkeyType uses if you don't provide your own;

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -101,30 +101,31 @@ Subclassing ``Config`` or ``DefaultConfig``
 
   .. method:: cli_context(command: str) -> Iterator[None]
 
-    A context manager which wraps the execution of the CLI command. Use it to
-    perform any initialization or cleanup required by your codebase.
+    A context manager which wraps the execution of the CLI command.
 
-    ``command`` is the command passed to the monkeytype cli: ``'run'``,
-    ``'apply'``, etc.
+    MonkeyType has to import your code in order to generate stubs for it. In
+    some cases, like if you're using Django, setup is required before your code
+    can be imported. Use this method to define the necessary setup or teardown
+    for your codebase.
 
-    Since :meth:`cli_context` is used as a context manager, any :class:`Config`
-    subclass that implements this method needs to decorate it with a context
-    decorator like :meth:`contextlib.contextmanager`, and needs to yield in
-    the body of the method exactly once. Code that comes before the yield will
-    run before the command starts, and code that comes afterward will run when
-    the command finishes but before the CLI exits.
+    This method must return a `context manager`_ instance. In most cases, the
+    simplest way to do this will be with the `contextlib.contextmanager`_
+    decorator. For example, if you run MonkeyType against a Django codebase,
+    you can setup Django before the command runs::
 
-    For example, if you run MonkeyType against a Django codebase, you can use
-    this method to setup Django before the command runs::
-
-      @contextmanager()
+      @contextmanager
       def cli_context(self, command: str) -> Iterator[None]:
           import django
           django.setup()
           yield
 
-    The default implementation of this method just calls ``yield`` to let the
-    command run.
+    ``command`` is the name of the command passed to the monkeytype cli:
+    ``'run'``, ``'apply'``, etc.
+
+    The default implementation of this method returns a no-op context manager.
+
+    .. _context manager: https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers
+    .. _contextlib.contextmanager: https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager
 
 .. class:: DefaultConfig()
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -184,7 +184,8 @@ def main(argv: List[str], stdout: IO, stderr: IO) -> int:
             "else monkeytype.config:DefaultConfig())"
         ),
     )
-    subparsers = parser.add_subparsers()
+
+    subparsers = parser.add_subparsers(title="commands", dest="command")
 
     run_parser = subparsers.add_parser(
         'run',
@@ -234,11 +235,15 @@ qualname format.""")
 
     args = parser.parse_args(argv)
     update_args_from_config(args)
+
     handler = getattr(args, 'handler', None)
     if handler is None:
         parser.print_help(file=stderr)
         return 1
+
+    args.config.cli_setup(args.command)
     handler(args, stdout, stderr)
+    args.config.cli_teardown(args.command)
     return 0
 
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -241,31 +241,8 @@ qualname format.""")
         parser.print_help(file=stderr)
         return 1
 
-    handler_exception: Optional[Exception] = None
-    try:
-        with args.config.cli_context(args.command):
-            # Capture the handler exception so it doesn't inadvertently trigger the cli_context() helper errors.
-            try:
-                handler(args, stdout, stderr)
-            except Exception as e:
-                handler_exception = e
-    except (AttributeError, RuntimeError, TypeError) as e:
-        config_class = args.config.__class__.__name__
-
-        # Provide helpful error messages for common context manager mistakes.
-        if isinstance(e, AttributeError):
-            error_msg = f"{config_class}.cli_context() needs to be decorated with `@contextmanager()` or another " \
-                        f"context decorator, but it is not."
-        elif isinstance(e, RuntimeError):
-            error_msg = f"{config_class}.cli_context() should only yield once, but it yielded multiple times."
-        elif isinstance(e, TypeError):
-            error_msg = f"{config_class}.cli_context() needs to yield once, but it did not yield."
-
-        error_msg = f"{error_msg}\nSee: https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager"
-        raise RuntimeError(error_msg) from e
-
-    if handler_exception:
-        raise handler_exception
+    with args.config.cli_context(args.command):
+        handler(args, stdout, stderr)
 
     return 0
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -241,9 +241,32 @@ qualname format.""")
         parser.print_help(file=stderr)
         return 1
 
-    args.config.cli_setup(args.command)
-    handler(args, stdout, stderr)
-    args.config.cli_teardown(args.command)
+    handler_exception: Optional[Exception] = None
+    try:
+        with args.config.cli_context(args.command):
+            # Capture the handler exception so it doesn't inadvertently trigger the cli_context() helper errors.
+            try:
+                handler(args, stdout, stderr)
+            except Exception as e:
+                handler_exception = e
+    except (AttributeError, RuntimeError, TypeError) as e:
+        config_class = args.config.__class__.__name__
+
+        # Provide helpful error messages for common context manager mistakes.
+        if isinstance(e, AttributeError):
+            error_msg = f"{config_class}.cli_context() needs to be decorated with `@contextmanager()` or another " \
+                        f"context decorator, but it is not."
+        elif isinstance(e, RuntimeError):
+            error_msg = f"{config_class}.cli_context() should only yield once, but it yielded multiple times."
+        elif isinstance(e, TypeError):
+            error_msg = f"{config_class}.cli_context() needs to yield once, but it did not yield."
+
+        error_msg = f"{error_msg}\nSee: https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager"
+        raise RuntimeError(error_msg) from e
+
+    if handler_exception:
+        raise handler_exception
+
     return 0
 
 

--- a/monkeytype/config.py
+++ b/monkeytype/config.py
@@ -39,6 +39,24 @@ class Config(metaclass=ABCMeta):
         """Return the CallTraceStore for storage/retrieval of call traces."""
         pass
 
+    def cli_setup(self, command: str) -> None:
+        """Lifecycle hook that is called once right after the CLI
+        starts.
+
+        `command` is the name of the command passed to monkeytype
+        ('run', 'apply', etc).
+        """
+        pass
+
+    def cli_teardown(self, command: str) -> None:
+        """Lifecycle hook that is called once right before the CLI
+        exits.
+
+        `command` is the name of the command passed to monkeytype
+        ('run', 'apply', etc).
+        """
+        pass
+
     def trace_logger(self) -> CallTraceLogger:
         """Return the CallTraceLogger for logging call traces.
 

--- a/monkeytype/config.py
+++ b/monkeytype/config.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from contextlib import contextmanager
 import os
 import sys
 import sysconfig
@@ -12,7 +13,7 @@ from abc import (
     abstractmethod,
 )
 from types import CodeType
-from typing import Optional
+from typing import Optional, Iterator
 
 from monkeytype.db.base import (
     CallTraceStore,
@@ -39,23 +40,15 @@ class Config(metaclass=ABCMeta):
         """Return the CallTraceStore for storage/retrieval of call traces."""
         pass
 
-    def cli_setup(self, command: str) -> None:
+    @contextmanager
+    def cli_context(self, command: str) -> Iterator[None]:
         """Lifecycle hook that is called once right after the CLI
         starts.
 
         `command` is the name of the command passed to monkeytype
         ('run', 'apply', etc).
         """
-        pass
-
-    def cli_teardown(self, command: str) -> None:
-        """Lifecycle hook that is called once right before the CLI
-        exits.
-
-        `command` is the name of the command passed to monkeytype
-        ('run', 'apply', etc).
-        """
-        pass
+        yield
 
     def trace_logger(self) -> CallTraceLogger:
         """Return the CallTraceLogger for logging call traces.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ def test_no_traces(store_data, stdout, stderr):
     assert ret == 0
 
 
-def test_lifecycle_hooks_called(capsys, stdout, stderr):
+def test_cli_context_manager_activated(stdout, stderr):
     with mock.patch.object(DefaultConfig, 'cli_context') as mock_context:
         ret = cli.main(['-c', f'{__name__}:DefaultConfig()', 'stub', 'some.module'], stdout, stderr)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,3 +74,13 @@ def test_no_traces(store_data, stdout, stderr):
     assert stderr.getvalue() == "No traces found\n"
     assert stdout.getvalue() == ''
     assert ret == 0
+
+
+def test_lifecycle_hooks_called(capsys, stdout, stderr):
+    with mock.patch.object(DefaultConfig, 'cli_setup') as mock_setup, \
+            mock.patch.object(DefaultConfig, 'cli_teardown') as mock_teardown:
+        ret = cli.main(['-c', f'{__name__}:DefaultConfig()', 'stub', 'some.module'], stdout, stderr)
+
+        mock_setup.assert_called_once_with('stub')
+        mock_teardown.assert_called_once_with('stub')
+        assert ret == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,10 +77,8 @@ def test_no_traces(store_data, stdout, stderr):
 
 
 def test_lifecycle_hooks_called(capsys, stdout, stderr):
-    with mock.patch.object(DefaultConfig, 'cli_setup') as mock_setup, \
-            mock.patch.object(DefaultConfig, 'cli_teardown') as mock_teardown:
+    with mock.patch.object(DefaultConfig, 'cli_context') as mock_context:
         ret = cli.main(['-c', f'{__name__}:DefaultConfig()', 'stub', 'some.module'], stdout, stderr)
 
-        mock_setup.assert_called_once_with('stub')
-        mock_teardown.assert_called_once_with('stub')
+        mock_context.assert_called_once_with('stub')
         assert ret == 0


### PR DESCRIPTION
Addressing #28, this PR adds the `cli_context()` method to Config so the CLI can use it as a context manager when running its command.

The command name is passed so implementations can, e.g., not run `django.setup()` with `monkeytype run manage.py` (as that would be redundant) but still run it for `stub`/`apply`.