### PR TITLE
TypeVar instances also lack `__qualname__`

### DIFF
--- a/monkeytype/encoding.py
+++ b/monkeytype/encoding.py
@@ -58,6 +58,9 @@ def type_to_dict(typ: type) -> TypeDict:
         qualname = 'Union'
     elif isinstance(typ, _Any):
         qualname = 'Any'
+    # TODO: typeshed stub for TypeVar is object() instead of a type
+    elif isinstance(typ, TypeVar):  # type: ignore
+        qualname = 'TypeVar'
     else:
         qualname = typ.__qualname__
     d: TypeDict = {


### PR DESCRIPTION
Sharing a quick fix I needed to get to work on some of the projects I quickly gave this a shot on. It choked on trying to serialize TypeVar instances as it seems like it also lacks `__qualname__`.