### PR TITLE
Improve CLI error messages

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -8,6 +8,7 @@ import collections
 import difflib
 import importlib
 import inspect
+import os
 import os.path
 import runpy
 import subprocess
@@ -44,6 +45,11 @@ def module_path(path: str) -> Tuple[str, Optional[str]]:
     parts = path.split(':', 1)
     module = parts.pop(0)
     qualname = parts[0] if parts else None
+    if os.sep in module:  # Smells like a path
+        raise argparse.ArgumentTypeError(
+            f'{module} does not look like a valid Python import path'
+        )
+
     return module, qualname
 
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -55,6 +55,14 @@ def module_path_with_qualname(path: str) -> Tuple[str, str]:
     return module, qualname
 
 
+def complain_about_no_traces(args: argparse.Namespace, stderr: IO) -> None:
+    module, qualname = args.module_path
+    if qualname:
+        print(f'No traces found for specifier {module}:{qualname}', file=stderr)
+    else:
+        print(f'No traces found for module {module}', file=stderr)
+
+
 def monkeytype_config(path: str) -> Config:
     """Imports the config instance specified by path.
 
@@ -115,7 +123,7 @@ def apply_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None
     args.ignore_existing_annotations = False
     stub = get_stub(args, stdout, stderr)
     if stub is None:
-        print(f'No traces found', file=stderr)
+        complain_about_no_traces(args, stderr)
         return
     module = args.module_path[0]
     mod = importlib.import_module(module)
@@ -164,7 +172,8 @@ def print_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None
         if stub is not None:
             output = stub.render()
     if output is None:
-        output, file = 'No traces found', stderr
+        complain_about_no_traces(args, stderr)
+        return
     print(output, file=file)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,11 +171,15 @@ def test_get_diff2(store_data, stdout, stderr):
     assert ret == 0
 
 
-def test_no_traces(store_data, stdout, stderr):
+@pytest.mark.parametrize('arg, error', [
+    (func.__module__, f"No traces found for module {func.__module__}\n"),
+    (func.__module__ + ':foo', f"No traces found for specifier {func.__module__}:foo\n"),
+])
+def test_no_traces(store_data, stdout, stderr, arg, error):
     store, db_file = store_data
     with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
-        ret = cli.main(['stub', func.__module__], stdout, stderr)
-    assert stderr.getvalue() == "No traces found\n"
+        ret = cli.main(['stub', arg], stdout, stderr)
+    assert stderr.getvalue() == error
     assert stdout.getvalue() == ''
     assert ret == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,3 +239,12 @@ def test_cli_context_manager_activated(capsys, stdout, stderr):
     assert out == "IN SETUP: stub\nIN TEARDOWN: stub\n"
     assert err == ""
     assert ret == 0
+
+
+def test_pathlike_parameter(store_data, capsys):
+    store, db_file = store_data
+    with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
+        with pytest.raises(SystemExit):
+            cli.main(['stub', 'test/foo.py:bar'], stdout, stderr)
+        out, err = capsys.readouterr()
+        assert "test/foo.py does not look like a valid Python import path" in err


### PR DESCRIPTION
This PR makes the CLI error messages a little more explicit.

I was trying to mistakenly pass in file system paths for modules, which didn't work. :)