### PR TITLE
Improve the default code filter's correctness and performance.

### DIFF
--- a/monkeytype/config.py
+++ b/monkeytype/config.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 from contextlib import contextmanager
+import functools
 import os
 import pathlib
 import sys
@@ -106,6 +107,7 @@ def _startswith(a: pathlib.Path, b: pathlib.Path) -> bool:
         return False
 
 
+@functools.lru_cache()
 def default_code_filter(code: CodeType) -> bool:
     """A CodeFilter to exclude stdlib and site-packages."""
     # Filter code without a source file

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ class TestDefaultCodeFilter:
         assert not config.default_code_filter(pytest.skip.__code__)
 
     def test_includes_otherwise(self):
-        assert config.default_code_filter(config.default_code_filter.__code__)
+        assert config.default_code_filter(config.default_code_filter.__wrapped__.__code__)
 
     def test_excludes_frozen_importlib(self):
         assert not config.default_code_filter(_frozen_importlib.spec_from_loader.__code__)


### PR DESCRIPTION
We need to fully resolve the filename when deciding to filter code because of possible discrepancies that might arise with symlinks (e.g. `/lib64` is symlinked to `/lib` - see #33).

Added a cache around the default filter as well since its essentially pure and adding symlink resolution created an incredibly large performance overhead. Fortunately, with the cache in place, this tool performs even faster than without the patch.