### PR TITLE
Add support to directly run a module

### DIFF
--- a/doc/tracing.rst
+++ b/doc/tracing.rst
@@ -33,12 +33,12 @@ script under MonkeyType tracing using ``monkeytype run`` or
 ``monkeytype stub`` and ``monkeytype apply``, to point MonkeyType to the config
 it should use.
 
-Because of the way Python treats scripts and modules differently,
-MonkeyType will record usable traces for modules imported and used by
-the entry point (where ``__name__ == "__main__"``) and not for the
-entry point itself. If you want to annotate the entry point, treat it
-as a module and write another short script that imports and calls its
-function(s), and run that script with ``monkeytype run``.
+Because of the way Python treats scripts and imported modules differently,
+MonkeyType will not record traces for the entry point itself (that is, the script
+passed to ``monkeytype run`` or the module passed to ``run -m``); traces are
+recorded only for imported modules. If you want to annotate the entry point
+script/module, write another short script that imports and calls its function(s),
+and run that script with ``monkeytype run``.
 
 .. module:: monkeytype
 

--- a/doc/tracing.rst
+++ b/doc/tracing.rst
@@ -23,17 +23,20 @@ monkeytype run
 ~~~~~~~~~~~~~~
 
 The simplest way to trace some function calls with MonkeyType is to run a Python
-script under MonkeyType tracing using ``monkeytype run`` at the command line::
+script under MonkeyType tracing using ``monkeytype run`` or
+``monkeytype run -m`` at the command line::
 
   $ monkeytype run myscript.py
+  $ monkeytype run -m mymodule
 
 ``monkeytype run`` accepts the same :option:`monkeytype -c` option as
 ``monkeytype stub`` and ``monkeytype apply``, to point MonkeyType to the config
 it should use.
 
-Because of the way Python treats scripts and modules differently, MonkeyType
-will record usable traces for modules imported and used by ``myscript.py``; not
-for ``myscript.py`` itself. If you want to annotate ``myscript.py``, treat it
+Because of the way Python treats scripts and modules differently,
+MonkeyType will record usable traces for modules imported and used by
+the entry point (where ``__name__ == "__main__"``) and not for the
+entry point itself. If you want to annotate the entry point, treat it
 as a module and write another short script that imports and calls its
 function(s), and run that script with ``monkeytype run``.
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -124,10 +124,14 @@ def print_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None
 def run_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:
     # remove initial `monkeytype run`
     old_argv = sys.argv.copy()
-    sys.argv = sys.argv[2:]
     try:
         with trace(args.config):
-            runpy.run_path(args.script_path, run_name='__main__')
+            if args.m:
+                sys.argv = sys.argv[3:]
+                runpy.run_module(args.script_path, run_name='__main__', alter_sys=True)
+            else:
+                sys.argv = sys.argv[2:]
+                runpy.run_path(args.script_path, run_name='__main__')
     finally:
         sys.argv = old_argv
 
@@ -195,6 +199,11 @@ def main(argv: List[str], stdout: IO, stderr: IO) -> int:
         'script_path',
         type=str,
         help="""Filesystem path to a Python script file to run under tracing""")
+    run_parser.add_argument(
+        '-m',
+        action='store_true',
+        help="Run a library module as a script"
+    )
     run_parser.add_argument(
         'script_args',
         nargs=argparse.REMAINDER,

--- a/monkeytype/tracing.py
+++ b/monkeytype/tracing.py
@@ -240,6 +240,7 @@ class CallTracer:
         code = frame.f_code
         if (
             event not in SUPPORTED_EVENTS or
+            frame.f_globals.get('__name__') == '__main__' or
             code.co_name == 'trace_types' or
             self.should_trace and not self.should_trace(code)
         ):


### PR DESCRIPTION
One small feature I would greatly appreciate so I don't have to write my own wrapper scripts: to be able to directly run modules directly just like (`python -m ...`).

I typically heavily lean on entry points scripts and the like when deploying python code, making `runpy.run_script` unpractical.

Feel free to bike shed, or decide you want a different verb, etc, but I'd greatly appreciate it if we can teach MonkeyType how to do this natively.