### PR TITLE
EHN: modify the example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Or enable call-trace logging for a block of code in ``myscript.py``::
   import monkeytype
 
   with monkeytype.trace():
-      ...a block of code in myscript.py
+      ...
 
 By default this will dump call traces into a sqlite database in the file
 ``monkeytype.sqlite3`` in the current working directory. You can then use the

--- a/README.rst
+++ b/README.rst
@@ -5,12 +5,10 @@ MonkeyType collects runtime types of function arguments and return values, and
 can automatically generate stub files or even add draft type annotations
 directly to your Python code based on the types collected at runtime.
 
-Examples
---------
+Example
+-------
 
-In the example, we have two files: ``some/module.py`` and ``myscript.py``.
-
-Say ``some/module.py`` originally contained::
+Say ``some/module.py`` originally contains::
 
   def add(a, b):
       return a + b
@@ -31,14 +29,23 @@ By default this will dump call traces into a sqlite database in the file
 ``monkeytype`` command to generate a stub file for a module, or apply the type
 annotations directly to your code.
 
-Run ``monkeytype stub some.module`` will give a stub::
+Running ``monkeytype stub some.module`` will output a stub::
 
   def add(a: int, b: int) -> int: ...
 
-Run  ``monkeytype apply some.module`` will modify ``some/module.py`` to::
+Running  ``monkeytype apply some.module`` will modify ``some/module.py`` to::
 
   def add(a: int, b: int) -> int:
       return a + b
+
+This example demonstrates both the value and the limitations of
+MonkeyType. With MonkeyType, it's very easy to add annotations that
+reflect the concrete types you use at runtime, but those annotations may not
+always match the full intended capability of the functions. For instance, ``add``
+is capable of handling many more types than just integers. Similarly, MonkeyType
+may generate a concrete ``List`` annotation where an abstract ``Sequence`` or
+``Iterable`` would be more appropriate. MonkeyType's annotations are an
+informative first draft, to be checked and corrected by a developer.
 
 Requirements
 ------------
@@ -74,18 +81,6 @@ stub files directly to your code.
 See `the full documentation`_ for details.
 
 .. _the full documentation: http://monkeytype.readthedocs.io/en/latest/
-
-Limitations
------------
-
-The example above demonstrates both the value and the limitations of
-MonkeyType. With MonkeyType, it's very easy to add type annotations that
-reflect the concrete types you use at runtime, but those annotations may not
-always match the full intended capability of the functions (e.g. this ``add``
-function is capable of handling many more types than just integers, or
-MonkeyType may generate a ``List`` annotation where ``Sequence`` or
-``Iterable`` would be more appropriate). MonkeyType's annotations are intended
-as a first draft, to be checked and corrected by a developer.
 
 Troubleshooting
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -22,46 +22,23 @@ And ``myscript.py`` contains::
   add(1, 2)
 
 Now we want to infer the type annotation of ``add`` in ``some/module.py`` by
-running ``myscript.py`` with ``MonkeyType``. This is supported in two ways:
-
-Run a script under call-trace logging of functions and methods in all imported
-modules::
+running ``myscript.py`` with ``MonkeyType``. One way is to run::
 
   $ monkeytype run myscript.py
-
-Or enable call-trace logging for a block of code in ``myscript.py``::
-
-  import monkeytype
-
-  with monkeytype.trace():
-      ...
 
 By default this will dump call traces into a sqlite database in the file
 ``monkeytype.sqlite3`` in the current working directory. You can then use the
 ``monkeytype`` command to generate a stub file for a module, or apply the type
-annotations directly to your code::
+annotations directly to your code.
 
-  $ monkeytype stub some.module
-  $ monkeytype apply some.module
-
-Then you'd get a stub like this from ``monkeytype stub some.module``::
+Run ``monkeytype stub some.module`` will give a stub::
 
   def add(a: int, b: int) -> int: ...
 
-And if you run ``monkeytype apply some.module``, ``some/module.py`` will be
-modified to::
+Run  ``monkeytype apply some.module`` will modify ``some/module.py`` to
 
   def add(a: int, b: int) -> int:
       return a + b
-
-This example demonstrates both the value and the limitations of
-MonkeyType. With MonkeyType, it's very easy to add type annotations that
-reflect the concrete types you use at runtime, but those annotations may not
-always match the full intended capability of the functions (e.g. this ``add``
-function is capable of handling many more types than just integers, or
-MonkeyType may generate a ``List`` annotation where ``Sequence`` or
-``Iterable`` would be more appropriate). MonkeyType's annotations are intended
-as a first draft, to be checked and corrected by a developer.
 
 Requirements
 ------------
@@ -97,6 +74,18 @@ stub files directly to your code.
 See `the full documentation`_ for details.
 
 .. _the full documentation: http://monkeytype.readthedocs.io/en/latest/
+
+Limitations
+-----------
+
+The example above demonstrates both the value and the limitations of
+MonkeyType. With MonkeyType, it's very easy to add type annotations that
+reflect the concrete types you use at runtime, but those annotations may not
+always match the full intended capability of the functions (e.g. this ``add``
+function is capable of handling many more types than just integers, or
+MonkeyType may generate a ``List`` annotation where ``Sequence`` or
+``Iterable`` would be more appropriate). MonkeyType's annotations are intended
+as a first draft, to be checked and corrected by a developer.
 
 Troubleshooting
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -8,27 +8,9 @@ directly to your Python code based on the types collected at runtime.
 Examples
 --------
 
-Run a script under call-trace logging of functions and methods in all imported
-modules::
+In the example, we have two files: ``some/module.py`` and ``myscript.py``.
 
-  $ monkeytype run myscript.py
-
-Or enable call-trace logging for a block of code::
-
-  import monkeytype
-
-  with monkeytype.trace():
-      ...
-
-By default this will dump call traces into a sqlite database in the file
-``monkeytype.sqlite3`` in the current working directory. You can then use the
-``monkeytype`` command to generate a stub file for a module, or apply the type
-annotations directly to your code::
-
-  $ monkeytype stub some.module
-  $ monkeytype apply some.module
-
-If ``some/module.py`` originally contained::
+Say ``some/module.py`` originally contained::
 
   def add(a, b):
       return a + b
@@ -38,6 +20,29 @@ And ``myscript.py`` contains::
   from some.module import add
 
   add(1, 2)
+
+Now we want to infer the type annotation of ``add`` in ``some/module.py`` by
+running ``myscript.py`` with ``MonkeyType``. This is supported in two ways:
+
+Run a script under call-trace logging of functions and methods in all imported
+modules::
+
+  $ monkeytype run myscript.py
+
+Or enable call-trace logging for a block of code in ``myscript.py``::
+
+  import monkeytype
+
+  with monkeytype.trace():
+      ...a block of code in myscript.py
+
+By default this will dump call traces into a sqlite database in the file
+``monkeytype.sqlite3`` in the current working directory. You can then use the
+``monkeytype`` command to generate a stub file for a module, or apply the type
+annotations directly to your code::
+
+  $ monkeytype stub some.module
+  $ monkeytype apply some.module
 
 Then you'd get a stub like this from ``monkeytype stub some.module``::
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Run ``monkeytype stub some.module`` will give a stub::
 
   def add(a: int, b: int) -> int: ...
 
-Run  ``monkeytype apply some.module`` will modify ``some/module.py`` to
+Run  ``monkeytype apply some.module`` will modify ``some/module.py`` to::
 
   def add(a: int, b: int) -> int:
       return a + b


### PR DESCRIPTION
I tried to make the example more easy to follow by rearranging the sequence that information is presented. 

First, let users know what the two files contain. Then, start to work on the annotation part.
