### PR TITLE
Add support for django.utils.functional.cached_property

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ pytest-smartcov = "*"
 cython = "*"
 sphinx = "*"
 twine = "*"
+django = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,20 +1,20 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4f2cf5346e51b582fb8f7efdb92750af7a7cb5ee2eeaf619d078a3acbcfad390"
+            "sha256": "0253689044f5d2d1261d1af60fa81ea8c1bb3bfd021455eabf5e675ba7fd644d"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
+            "implementation_version": "3.6.4",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "4.6.0-040600-generic",
-            "platform_system": "Linux",
-            "platform_version": "#201605151930 SMP Sun May 15 23:32:59 UTC 2016",
-            "python_full_version": "3.6.3",
+            "platform_release": "15.6.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 15.6.0: Tue Apr 11 16:00:51 PDT 2017; root:xnu-3248.60.11.5.3~1/RELEASE_X86_64",
+            "python_full_version": "3.6.4",
             "python_version": "3.6",
-            "sys_platform": "linux"
+            "sys_platform": "darwin"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,10 +39,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:e7d51b70f19a4da5fe6b3c9938983e0af3b91e230edc504bd73c443d98037063",
-                "sha256:c78f53e32d7cf36d8597c8a2c7e3c0ad210f97b9509e152e4c37fa80869f823c"
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450",
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
             ],
-            "version": "==17.3.0"
+            "version": "==17.4.0"
         },
         "babel": {
             "hashes": [
@@ -65,12 +65,12 @@
             ],
             "version": "==3.0.4"
         },
-        "configparser": {
+        "click": {
             "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
+                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
+                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
             ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
+            "version": "==6.7"
         },
         "coverage": {
             "hashes": [
@@ -152,6 +152,13 @@
             ],
             "version": "==0.27.3"
         },
+        "django": {
+            "hashes": [
+                "sha256:52475f607c92035d4ac8fee284f56213065a4a6b25ed43f7e39df0e576e69e9f",
+                "sha256:d96b804be412a5125a594023ec524a2010a6ffa4d408e5482ab6ff3cb97ec12f"
+            ],
+            "version": "==2.0.1"
+        },
         "docutils": {
             "hashes": [
                 "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6",
@@ -164,30 +171,12 @@
             "editable": true,
             "path": "."
         },
-        "enum34": {
-            "hashes": [
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
-        },
         "flake8": {
             "hashes": [
                 "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37",
                 "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0"
             ],
             "version": "==3.5.0"
-        },
-        "funcsigs": {
-            "hashes": [
-                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
-                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-            ],
-            "markers": "python_version < '3.0'",
-            "version": "==1.0.2"
         },
         "idna": {
             "hashes": [
@@ -225,10 +214,10 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0d66ca31ec6a51e465f68634e9daf363b877f0caa19a7f1d6319a743fb709d25",
-                "sha256:58302374890b9803b19a5547e2229f8bab46900624a2f31f398b231e5f461929"
+                "sha256:aa668809ae0dbec5e9feb8929f4b5e1f9318a0a397447fa2f38c382a2ed6a036",
+                "sha256:bd0c9a2fcf0c4f7a54a2b625f466fcc000d415f371298d96fa5d2acc69074aca"
             ],
-            "version": "==0.550"
+            "version": "==0.560"
         },
         "pkginfo": {
             "hashes": [
@@ -245,17 +234,17 @@
         },
         "psutil": {
             "hashes": [
-                "sha256:2fbbc7dce43c5240b9dc6d56302d57412f1c5a0d665d1f04eb05a6b7279f4e9b",
-                "sha256:259ec8578d19643179eb2377348c63b650b51ba40f58f2620a3d9732b8a0b557",
-                "sha256:d3808be8241433db17fa955566c3b8be61dac8ba8f221dcbb202a9daba918db5",
-                "sha256:449747f638c221f8ce6ca3548aefef13339aa05b453cc1f233f4d6c31c206198",
-                "sha256:f6c2d54abd59ed8691882de7fd6b248f5808a567885f20f50b3b4b9eedaebb1f",
-                "sha256:e3d00d8fc3d4217f05d07af45390f072c04cb7c7dddd70b86b728e5fbe485c81",
-                "sha256:3473d6abad9d6ec7b8a97f4dc55f0b3483ecf470d85f08f5e23c1c07592b914f",
-                "sha256:7dc6c3bbb5d28487f791f195d6abfdef295d34c44ce6cb5f2d178613fb3338ab",
-                "sha256:00a1f9ff8d1e035fba7bfdd6977fa8ea7937afdb4477339e5df3dba78194fe11"
+                "sha256:82a06785db8eeb637b349006cc28a92e40cd190fefae9875246d18d0de7ccac8",
+                "sha256:4152ae231709e3e8b80e26b6da20dc965a1a589959c48af1ed024eca6473f60d",
+                "sha256:230eeb3aeb077814f3a2cd036ddb6e0f571960d327298cc914c02385c3e02a63",
+                "sha256:a3286556d4d2f341108db65d8e20d0cd3fcb9a91741cb5eb496832d7daf2a97c",
+                "sha256:94d4e63189f2593960e73acaaf96be235dd8a455fe2bcb37d8ad6f0e87f61556",
+                "sha256:c91eee73eea00df5e62c741b380b7e5b6fdd553891bee5669817a3a38d036f13",
+                "sha256:779ec7e7621758ca11a8d99a1064996454b3570154277cc21342a01148a49c28",
+                "sha256:8a15d773203a1277e57b1d11a7ccdf70804744ef4a9518a87ab8436995c31a4b",
+                "sha256:e2467e9312c2fa191687b89ff4bc2ad8843be4af6fb4dc95a7cc5f7d7a327b18"
             ],
-            "version": "==5.4.2"
+            "version": "==5.4.3"
         },
         "py": {
             "hashes": [
@@ -326,6 +315,13 @@
             ],
             "version": "==0.8.0"
         },
+        "retype": {
+            "hashes": [
+                "sha256:33cfb36601bfeb355924731d8db78fa82f3f12eb37e87236e9179d81aba97740",
+                "sha256:b64b767befbe6f5fd918603ab7d6bbff07fc4c431bae2f471e195677a0c9b327"
+            ],
+            "version": "==17.12.0"
+        },
         "six": {
             "hashes": [
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
@@ -390,15 +386,6 @@
                 "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa"
             ],
             "version": "==1.1.0"
-        },
-        "typing": {
-            "hashes": [
-                "sha256:349b1f9c109c84b53ac79ac1d822eaa68fc91d63b321bd9392df15098f746f53",
-                "sha256:63a8255fe7c6269916baa440eb9b6a67139b0b97a01af632e7bd2842e1e02f15",
-                "sha256:d514bd84b284dd3e844f0305ac07511f097e325171f6cc4a20878d11ad771849"
-            ],
-            "markers": "python_version < '3.5'",
-            "version": "==3.6.2"
         },
         "urllib3": {
             "hashes": [

--- a/monkeytype/tracing.py
+++ b/monkeytype/tracing.py
@@ -27,6 +27,11 @@ from typing import (
     cast,
 )
 
+try:
+    from django.utils.functional import cached_property  # type: ignore
+except ImportError:
+    cached_property = None
+
 from monkeytype.typing import get_type
 from monkeytype.util import get_func_fqname
 
@@ -112,6 +117,8 @@ def get_func_in_mro(obj: Any, code: CodeType) -> Optional[Callable]:
         cand = cast(Callable, val.__func__)
     elif isinstance(val, property) and (val.fset is None) and (val.fdel is None):
         cand = cast(Callable, val.fget)
+    elif cached_property and isinstance(val, cached_property):
+        cand = cast(Callable, val.func)
     else:
         cand = cast(Callable, val)
     return _has_code(cand, code)

--- a/monkeytype/util.py
+++ b/monkeytype/util.py
@@ -7,6 +7,11 @@ import importlib
 import inspect
 import types
 
+try:
+    from django.utils.functional import cached_property  # type: ignore
+except ImportError:
+    cached_property = None
+
 from typing import (
     Any,
     Callable,
@@ -46,6 +51,8 @@ def get_func_in_module(module: str, qualname: str) -> Callable:
         else:
             raise InvalidTypeError(
                 f"Property {module}.{qualname} is missing getter")
+    elif cached_property and isinstance(func, cached_property):
+        func = func.func
     elif not isinstance(func, (types.FunctionType, types.BuiltinFunctionType)):
         raise InvalidTypeError(
             f"{module}.{qualname} is of type '{type(func)}', not function.")

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -205,6 +205,15 @@ class TestFunctionStub:
         ])
         assert stub.render() == expected
 
+    def test_cached_property(self):
+        stub = FunctionStub('test',
+                            inspect.signature(Dummy.a_cached_property.func), FunctionKind.DJANGO_CACHED_PROPERTY)
+        expected = "\n".join([
+            '@cached_property',
+            'def test%s: ...' % (render_signature(stub.signature),),
+        ])
+        assert stub.render() == expected
+
     def test_simple(self):
         for kind in [FunctionKind.MODULE, FunctionKind.INSTANCE]:
             stub = FunctionStub('test', inspect.signature(simple_add), kind)
@@ -477,6 +486,7 @@ class TestFunctionKind:
             (Dummy.a_class_method.__func__, FunctionKind.CLASS),
             (Dummy.an_instance_method, FunctionKind.INSTANCE),
             (Dummy.a_property.fget, FunctionKind.PROPERTY),
+            (Dummy.a_cached_property.func, FunctionKind.DJANGO_CACHED_PROPERTY),
             (a_module_func, FunctionKind.MODULE),
         ],
     )
@@ -492,6 +502,7 @@ class TestFunctionDefinition:
             (Dummy.a_class_method.__func__, True),
             (Dummy.an_instance_method, True),
             (Dummy.a_property.fget, True),
+            (Dummy.a_cached_property.func, True),
             (a_module_func, False),
         ],
     )
@@ -514,6 +525,9 @@ class TestFunctionDefinition:
             (Dummy.a_property.fget, FunctionDefinition(
                 'tests.util', 'Dummy.a_property', FunctionKind.PROPERTY,
                 Signature.from_callable(Dummy.a_property.fget))),
+            (Dummy.a_cached_property.func, FunctionDefinition(
+                'tests.util', 'Dummy.a_cached_property', FunctionKind.DJANGO_CACHED_PROPERTY,
+                Signature.from_callable(Dummy.a_cached_property.func))),
             (a_module_func, FunctionDefinition(
                 'tests.test_stubs', 'a_module_func', FunctionKind.MODULE,
                 Signature.from_callable(a_module_func))),

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -11,6 +11,7 @@ from typing import (
 )
 
 import pytest
+from django.utils.functional import cached_property
 
 from monkeytype.tracing import (
     CallTrace,
@@ -69,6 +70,10 @@ class GetFuncHelper:
     def a_property(self) -> Optional[FrameType]:
         return inspect.currentframe()
 
+    @cached_property
+    def a_cached_property(self) -> Optional[FrameType]:
+        return inspect.currentframe()
+
 
 def a_module_function() -> Optional[FrameType]:
     return inspect.currentframe()
@@ -83,6 +88,7 @@ class TestGetFunc:
             (GetFuncHelper().an_instance_method(), GetFuncHelper.an_instance_method),
             (a_module_function(), a_module_function),
             (GetFuncHelper().a_property, GetFuncHelper.a_property.fget),
+            (GetFuncHelper().a_cached_property, GetFuncHelper.a_cached_property.func),
         ],
     )
     def test_get_func(self, frame, expected_func):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -61,6 +61,13 @@ class TestGetFuncInModule:
         with pytest.raises(InvalidTypeError):
             get_func_in_module(func.__module__, func.__qualname__)
 
+    def test_get_cached_property(self):
+        """We should be able to look up properties that are decorated
+        with django.utils.functional.cached_property"""
+        func = Dummy.a_cached_property.func
+        obj = get_func_in_module(func.__module__, func.__qualname__)
+        assert obj == func
+
     def test_get_non_function(self):
         """Raise an error if lookup returns something that isn't a function"""
         with pytest.raises(InvalidTypeError):

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Optional,
 )
+from django.utils.functional import cached_property
 
 
 class Dummy:
@@ -35,6 +36,10 @@ class Dummy:
 
     @a_settable_property.setter
     def a_settable_property(self, unused) -> Optional[FrameType]:
+        return inspect.currentframe()
+
+    @cached_property
+    def a_cached_property(self) -> Optional[FrameType]:
         return inspect.currentframe()
 
 


### PR DESCRIPTION
Howdy, I think this is what is needed for #9. It passes `pytest`, `flake`, and `mypy`. I'm not sure if I completely mangled the `Pipfile.lock` file though.

<img width="473" alt="screen shot 2018-01-03 at 10 51 05 pm" src="https://user-images.githubusercontent.com/4838266/34550705-a1364742-f0d8-11e7-8371-6af53038ae49.png">

  