### PR TITLE
Support sample count

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -14,7 +14,6 @@ import sys
 import tempfile
 
 from typing import (
-    Dict,
     IO,
     List,
     Optional,
@@ -75,16 +74,10 @@ def monkeytype_config(path: str) -> Config:
     return config
 
 
-def count_sample(traces: List[CallTrace]) -> Dict[str, int]:
-    """Count the times each function is traced."""
-    counter = collections.Counter([t.funcname for t in traces])
-    return dict(counter.most_common())
-
-
 def display_sample_count(traces: List[CallTrace], stderr: IO) -> None:
-    """Print to stderr the statistics for generating stubs."""
-    sample_count = count_sample(traces)
-    for name, count in sample_count.items():
+    """Print to stderr the number of traces each stub is based on."""
+    sample_counter = collections.Counter([t.funcname for t in traces])
+    for name, count in sample_counter.items():
         print(f"Annotation for {name} based on {count} call trace(s).", file=stderr)
 
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -14,7 +14,6 @@ import sys
 import tempfile
 
 from typing import (
-    Callable,
     Dict,
     IO,
     List,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,49 @@ def test_no_traces(store_data, stdout, stderr):
     assert ret == 0
 
 
+def test_count_sample():
+    traces = [
+        CallTrace(func, {'a': int, 'b': str}, NoneType),
+        CallTrace(func, {'a': str, 'b': str}, NoneType),
+        CallTrace(func2, {'a': str, 'b': int}, NoneType),
+        CallTrace(func2, {'a': int, 'b': str}, NoneType),
+        CallTrace(func2, {'a': str, 'b': int}, NoneType)
+    ]
+    ret = cli.count_sample(traces)
+    assert ret == {'tests.test_cli.func2': 3, 'tests.test_cli.func': 2}
+
+
+def test_display_sample_count(capsys, stderr):
+    traces = [
+        CallTrace(func, {'a': int, 'b': str}, NoneType),
+        CallTrace(func, {'a': str, 'b': str}, NoneType),
+        CallTrace(func2, {'a': str, 'b': int}, NoneType),
+        CallTrace(func2, {'a': int, 'b': str}, NoneType),
+        CallTrace(func2, {'a': str, 'b': int}, NoneType)
+    ]
+    cli.display_sample_count(traces, stderr)
+    expected = """Annotation for tests.test_cli.func2 based on 3 call trace(s).
+Annotation for tests.test_cli.func based on 2 call trace(s).
+"""
+    assert stderr.getvalue() == expected
+
+
+def test_display_sample_count_from_cli(store_data, stdout, stderr):
+    store, db_file = store_data
+    traces = [
+        CallTrace(func, {'a': int, 'b': str}, NoneType),
+        CallTrace(func2, {'a': int, 'b': int}, NoneType),
+    ]
+    store.add(traces)
+    with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
+        ret = cli.main(['stub', func.__module__, '--sample-count'], stdout, stderr)
+    expected = """Annotation for tests.test_cli.func based on 1 call trace(s).
+Annotation for tests.test_cli.func2 based on 1 call trace(s).
+"""
+    assert stderr.getvalue() == expected
+    assert ret == 0
+
+
 def test_cli_context_manager_activated(capsys, stdout, stderr):
     ret = cli.main(['-c', f'{__name__}:LoudContextConfig()', 'stub', 'some.module'], stdout, stderr)
     out, err = capsys.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,18 +86,6 @@ def test_no_traces(store_data, stdout, stderr):
     assert ret == 0
 
 
-def test_count_sample():
-    traces = [
-        CallTrace(func, {'a': int, 'b': str}, NoneType),
-        CallTrace(func, {'a': str, 'b': str}, NoneType),
-        CallTrace(func2, {'a': str, 'b': int}, NoneType),
-        CallTrace(func2, {'a': int, 'b': str}, NoneType),
-        CallTrace(func2, {'a': str, 'b': int}, NoneType)
-    ]
-    ret = cli.count_sample(traces)
-    assert ret == {'tests.test_cli.func2': 3, 'tests.test_cli.func': 2}
-
-
 def test_display_sample_count(capsys, stderr):
     traces = [
         CallTrace(func, {'a': int, 'b': str}, NoneType),
@@ -107,8 +95,8 @@ def test_display_sample_count(capsys, stderr):
         CallTrace(func2, {'a': str, 'b': int}, NoneType)
     ]
     cli.display_sample_count(traces, stderr)
-    expected = """Annotation for tests.test_cli.func2 based on 3 call trace(s).
-Annotation for tests.test_cli.func based on 2 call trace(s).
+    expected = """Annotation for tests.test_cli.func based on 2 call trace(s).
+Annotation for tests.test_cli.func2 based on 3 call trace(s).
 """
     assert stderr.getvalue() == expected
 


### PR DESCRIPTION
This pull request implements the enhancement suggested in issues #7 

It supports `--sample-count` argument for both `stub` and `apply` two subparsers. Currently, it prints "Annotation for module.func based on N call trace(s)." to `stderr` line by line for each method. 

Some points that I am not sure
- `--sample-count` argument is checked at the `get_stub` function. Or it should be checked at `apply_stub_handler` and `print_stub_handler` separately?
-  The two functions, `display_sample_count` and `count_sample` seems to be able to merge into one function. I wrote it separately to test it separately. Should I merge them? 

Some other thoughts 
- add sort by frequency support?

Please let me know if there is anything I miss or any naming issue. I appreciate your review.