### PR TITLE
Enhancement: ignore existing annotations

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -107,6 +107,7 @@ class HandlerError(Exception):
 
 
 def apply_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:
+    args.ignore_existing_annotations = False
     stub = get_stub(args, stdout, stderr)
     if stub is None:
         print(f'No traces found', file=stderr)

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -95,7 +95,8 @@ def get_stub(args: argparse.Namespace, stdout: IO, stderr: IO) -> Optional[Stub]
     rewriter = args.config.type_rewriter()
     if args.disable_type_rewriting:
         rewriter = NoOpRewriter()
-    stubs = build_module_stubs_from_traces(traces, args.include_unparsable_defaults, rewriter)
+    stubs = build_module_stubs_from_traces(traces, args.include_unparsable_defaults,
+                                           args.ignore_existing_annotations, rewriter)
     if args.sample_count:
         display_sample_count(traces, stderr)
     return stubs.get(module, None)

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -272,6 +272,12 @@ qualname format.""")
         default=False,
         help='Print to stderr the numbers of traces stubs are based on'
         )
+    stub_parser.add_argument(
+        "--ignore-existing-annotations",
+        action='store_true',
+        default=False,
+        help='Ignore existing annotations and generate stubs only from traces.'
+        )
     stub_parser.set_defaults(handler=print_stub_handler)
 
     args = parser.parse_args(argv)

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -99,7 +99,7 @@ def get_stub(args: argparse.Namespace, stdout: IO, stderr: IO) -> Optional[Stub]
         traces,
         include_unparsable_defaults=args.include_unparsable_defaults,
         ignore_existing_annotations=args.ignore_existing_annotations,
-        rewriter=rewriter
+        rewriter=rewriter,
     )
     if args.sample_count:
         display_sample_count(traces, stderr)
@@ -280,7 +280,7 @@ qualname format.""")
         "--ignore-existing-annotations",
         action='store_true',
         default=False,
-        help='Ignore existing annotations and generate stubs only from traces.'
+        help='Ignore existing annotations and generate stubs only from traces.',
         )
     stub_parser.set_defaults(handler=print_stub_handler)
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -95,8 +95,12 @@ def get_stub(args: argparse.Namespace, stdout: IO, stderr: IO) -> Optional[Stub]
     rewriter = args.config.type_rewriter()
     if args.disable_type_rewriting:
         rewriter = NoOpRewriter()
-    stubs = build_module_stubs_from_traces(traces, args.include_unparsable_defaults,
-                                           args.ignore_existing_annotations, rewriter)
+    stubs = build_module_stubs_from_traces(
+        traces,
+        include_unparsable_defaults=args.include_unparsable_defaults,
+        ignore_existing_annotations=args.ignore_existing_annotations,
+        rewriter=rewriter
+    )
     if args.sample_count:
         display_sample_count(traces, stderr)
     return stubs.get(module, None)

--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -194,7 +194,7 @@ def update_signature_args(
         typ = inspect.Parameter.empty if (typ is None or typ is NoneType) else typ
         is_self = (has_self and arg_idx == 0)
         annotated = param.annotation is not inspect.Parameter.empty
-        # Dont' touch existing annotations unless ignore_existing_annotations
+        # Don't touch existing annotations unless ignore_existing_annotations
         if not is_self and (ignore_existing_annotations or not annotated):
             param = param.replace(annotation=typ)
         params.append(param)
@@ -208,7 +208,7 @@ def update_signature_return(
         ignore_existing_annotations: bool = False) -> inspect.Signature:
     """Update return annotation with the supplied types"""
     anno = sig.return_annotation
-    # Dont' touch pre-existing annotations unless ignore_existing_annotations
+    # Don't touch pre-existing annotations unless ignore_existing_annotations
     if not ignore_existing_annotations and anno is not inspect.Signature.empty:
         return sig
     # NB: We cannot distinguish between functions that explicitly only

--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -191,7 +191,7 @@ def update_signature_args(
     for arg_idx, name in enumerate(sig.parameters):
         param = sig.parameters[name]
         typ = arg_types.get(name)
-        typ = inspect.Parameter.empty if (typ is None or typ is NoneType) else typ
+        typ = inspect.Parameter.empty if typ is None else typ
         is_self = (has_self and arg_idx == 0)
         annotated = param.annotation is not inspect.Parameter.empty
         # Don't touch existing annotations unless ignore_existing_annotations
@@ -245,7 +245,7 @@ def get_updated_definition(
     func: Callable,
     traces: Iterable[CallTrace],
     rewriter: Optional[TypeRewriter] = None,
-    ignore_existing_annotations: bool = False
+    ignore_existing_annotations: bool = False,
 ) -> FunctionDefinition:
     """Update the definition for func using the types collected in traces."""
     if rewriter is None:

--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -192,10 +192,10 @@ def update_signature_args(
         param = sig.parameters[name]
         typ = arg_types.get(name)
         typ = inspect.Parameter.empty if (typ is None or typ is NoneType) else typ
-        with_self = (has_self and arg_idx == 0)
+        is_self = (has_self and arg_idx == 0)
         annotated = param.annotation is not inspect.Parameter.empty
         # Dont' touch existing annotations unless ignore_existing_annotations
-        if not with_self and (ignore_existing_annotations or not annotated):
+        if not is_self and (ignore_existing_annotations or not annotated):
             param = param.replace(annotation=typ)
         params.append(param)
     return sig.replace(parameters=params)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,10 @@ def func2(a, b):
     pass
 
 
+def func_anno(a: int, b: str) -> None:
+    pass
+
+
 class LoudContextConfig(DefaultConfig):
     @contextmanager
     def cli_context(self, command: str) -> Iterator[None]:
@@ -72,6 +76,22 @@ def test_generate_stub(store_data, stdout, stderr):
 
 
 def func2(a: int, b: int) -> None: ...
+"""
+    assert stdout.getvalue() == expected
+    assert stderr.getvalue() == ''
+    assert ret == 0
+
+
+def test_print_stub_ignore_existing_annotations(store_data, stdout, stderr):
+    store, db_file = store_data
+    traces = [
+        CallTrace(func_anno, {'a': int, 'b': int}, int),
+    ]
+    store.add(traces)
+    with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
+        ret = cli.main(['stub', func.__module__, '--ignore-existing-annotations'],
+                       stdout, stderr)
+    expected = """def func_anno(a: int, b: int) -> int: ...
 """
     assert stdout.getvalue() == expected
     assert stderr.getvalue() == ''

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -426,6 +426,44 @@ class TestUpdateSignatureArgs:
         expected = Signature(parameters=[Parameter('cls', Parameter.POSITIONAL_OR_KEYWORD)])
         assert sig == expected
 
+    def test_update_arg_ignore_existing_anno(self):
+        """Update stubs only bases on traces."""
+        sig = Signature.from_callable(UpdateSignatureHelper.has_annos)
+        ignore_existing_annotations = True
+        sig = update_signature_args(sig, {'a': str, 'b': bool}, False, ignore_existing_annotations)
+        params = [
+            Parameter('a', Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+            Parameter('b', Parameter.POSITIONAL_OR_KEYWORD, annotation=bool),
+        ]
+        assert sig == Signature(parameters=params, return_annotation=int)
+
+    def test_update_self_ignore_existing_anno(self):
+        """Don't annotate first arg of instance methods with ignore_existing_annotations"""
+        sig = Signature.from_callable(UpdateSignatureHelper.an_instance_method)
+        sig = update_signature_args(sig, {'self': UpdateSignatureHelper}, True, True)
+        expected = Signature(parameters=[Parameter('self', Parameter.POSITIONAL_OR_KEYWORD)])
+        assert sig == expected
+
+    def test_update_arg_ignore_existing_anno_NoneType(self):
+        """Update arg annotations from types"""
+        sig = Signature.from_callable(UpdateSignatureHelper.has_annos)
+        sig = update_signature_args(sig, {'a': NoneType, 'b': int}, False, True)
+        params = [
+            Parameter('a', Parameter.POSITIONAL_OR_KEYWORD, annotation=inspect.Parameter.empty),
+            Parameter('b', Parameter.POSITIONAL_OR_KEYWORD, annotation=int),
+        ]
+        assert sig == Signature(parameters=params, return_annotation=int)
+
+    def test_update_arg_ignore_existing_anno_None(self):
+        """Update arg annotations from types"""
+        sig = Signature.from_callable(UpdateSignatureHelper.has_annos)
+        sig = update_signature_args(sig, {'a': None, 'b': int}, False, True)
+        params = [
+            Parameter('a', Parameter.POSITIONAL_OR_KEYWORD, annotation=inspect.Parameter.empty),
+            Parameter('b', Parameter.POSITIONAL_OR_KEYWORD, annotation=int),
+        ]
+        assert sig == Signature(parameters=params, return_annotation=int)
+
 
 class TestUpdateSignatureReturn:
     def test_update_return(self):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -429,8 +429,7 @@ class TestUpdateSignatureArgs:
     def test_update_arg_ignore_existing_anno(self):
         """Update stubs only bases on traces."""
         sig = Signature.from_callable(UpdateSignatureHelper.has_annos)
-        ignore_existing_annotations = True
-        sig = update_signature_args(sig, {'a': str, 'b': bool}, False, ignore_existing_annotations)
+        sig = update_signature_args(sig, {'a': str, 'b': bool}, has_self=False, ignore_existing_annotations=True)
         params = [
             Parameter('a', Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
             Parameter('b', Parameter.POSITIONAL_OR_KEYWORD, annotation=bool),
@@ -440,7 +439,8 @@ class TestUpdateSignatureArgs:
     def test_update_self_ignore_existing_anno(self):
         """Don't annotate first arg of instance methods with ignore_existing_annotations"""
         sig = Signature.from_callable(UpdateSignatureHelper.an_instance_method)
-        sig = update_signature_args(sig, {'self': UpdateSignatureHelper}, True, True)
+        sig = update_signature_args(sig, {'self': UpdateSignatureHelper}, has_self=True,
+                                    ignore_existing_annotations=True)
         expected = Signature(parameters=[Parameter('self', Parameter.POSITIONAL_OR_KEYWORD)])
         assert sig == expected
 
@@ -457,7 +457,7 @@ class TestUpdateSignatureArgs:
     def test_update_arg_ignore_existing_anno_None(self):
         """Update arg annotations from types"""
         sig = Signature.from_callable(UpdateSignatureHelper.has_annos)
-        sig = update_signature_args(sig, {'a': None, 'b': int}, False, True)
+        sig = update_signature_args(sig, {'a': None, 'b': int}, has_self=False, ignore_existing_annotations=True)
         params = [
             Parameter('a', Parameter.POSITIONAL_OR_KEYWORD, annotation=inspect.Parameter.empty),
             Parameter('b', Parameter.POSITIONAL_OR_KEYWORD, annotation=int),

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -444,16 +444,6 @@ class TestUpdateSignatureArgs:
         expected = Signature(parameters=[Parameter('self', Parameter.POSITIONAL_OR_KEYWORD)])
         assert sig == expected
 
-    def test_update_arg_ignore_existing_anno_NoneType(self):
-        """Update arg annotations from types"""
-        sig = Signature.from_callable(UpdateSignatureHelper.has_annos)
-        sig = update_signature_args(sig, {'a': NoneType, 'b': int}, False, True)
-        params = [
-            Parameter('a', Parameter.POSITIONAL_OR_KEYWORD, annotation=inspect.Parameter.empty),
-            Parameter('b', Parameter.POSITIONAL_OR_KEYWORD, annotation=int),
-        ]
-        assert sig == Signature(parameters=params, return_annotation=int)
-
     def test_update_arg_ignore_existing_anno_None(self):
         """Update arg annotations from types"""
         sig = Signature.from_callable(UpdateSignatureHelper.has_annos)

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -485,6 +485,19 @@ class TestUpdateSignatureReturn:
         )
         assert sig == expected
 
+    def test_update_return_with_anno_ignored(self):
+        """Leave existing return annotations alone"""
+        sig = Signature.from_callable(UpdateSignatureHelper.has_annos)
+        sig = update_signature_return(sig, return_type=str, ignore_existing_annotations=True)
+        expected = Signature(
+            parameters=[
+                Parameter('a', Parameter.POSITIONAL_OR_KEYWORD, annotation=int),
+                Parameter('b', Parameter.POSITIONAL_OR_KEYWORD)
+            ],
+            return_annotation=str
+        )
+        assert sig == expected
+
     def test_update_yield(self):
         sig = Signature.from_callable(UpdateSignatureHelper.a_class_method)
         sig = update_signature_return(sig, yield_type=int)


### PR DESCRIPTION
This PR implements the enhancement suggested in issue #15 

The `update_signature_args` part is a bit complicated, and I am not sure whether I am doing it right. 
I tested whether a `typ` is `None` or `NoneType`. If so, I assign it as `inspect.Parameter.empty`. I think is related to issue #5 when it regarding parameters. Not sure this is the correct way to do.

I also added one line to  `apply_stub_handler` because I did not add option for `apply_parser` subparser. I need to manually make it `False` and make `get_stub` function aware of the parameter when it is called by `apply_stub_handler`.

```python
 def apply_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:
     args.ignore_existing_annotations = False
```
I appreciate your the review.