### PR TITLE
Enhencement: stub --diff

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -149,7 +149,7 @@ def get_diff(args: argparse.Namespace, stdout: IO, stderr: IO) -> Optional[str]:
     seq2 = stub_ignore_anno.render().splitlines(keepends=True)
     diff = [s for s in difflib.ndiff(seq1, seq2) if s.startswith(("+", "-", "?"))]
     for i in range(len(diff) // 4 - 1):
-        diff.insert(5 * (i+1) - 1, "\n")
+        diff.insert(5 * (i+1) - 1, "\n\n\n")
     return "".join(diff)[:-1]
 
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -145,12 +145,14 @@ def get_diff(args: argparse.Namespace, stdout: IO, stderr: IO) -> Optional[str]:
     stub_ignore_anno = get_stub(args, stdout, stderr)
     if stub is None or stub_ignore_anno is None:
         return None
-    seq1 = stub.render().splitlines(keepends=True)
-    seq2 = stub_ignore_anno.render().splitlines(keepends=True)
-    diff = [s for s in difflib.ndiff(seq1, seq2) if s.startswith(("+", "-", "?"))]
-    for i in range(len(diff) // 4 - 1):
-        diff.insert(5 * (i+1) - 1, "\n\n\n")
-    return "".join(diff)[:-1]
+    diff = []
+    seq1 = (s + "\n" for s in stub.render().split("\n\n\n"))
+    seq2 = (s + "\n" for s in stub_ignore_anno.render().split("\n\n\n"))
+    for stub1, stub2 in zip(seq1, seq2):
+        if stub1 != stub2:
+            stub_diff = "".join(difflib.ndiff(stub1.splitlines(keepends=True), stub2.splitlines(keepends=True)))
+            diff.append(stub_diff[:-1])
+    return "\n\n\n".join(diff)
 
 
 def print_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -282,6 +282,12 @@ qualname format.""")
         default=False,
         help='Ignore existing annotations and generate stubs only from traces.',
         )
+    stub_parser.add_argument(
+        "--diff",
+        action='store_true',
+        default=False,
+        help='Compare stubs generated with or without considering existing annotations.',
+        )
     stub_parser.set_defaults(handler=print_stub_handler)
 
     args = parser.parse_args(argv)

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -156,18 +156,16 @@ def get_diff(args: argparse.Namespace, stdout: IO, stderr: IO) -> Optional[str]:
 
 
 def print_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:
+    output, file = None, stdout
     if args.diff:
         output = get_diff(args, stdout, stderr)
-        if output is None:
-            print(f'No traces found', file=stderr)
-            return
     else:
         stub = get_stub(args, stdout, stderr)
-        if stub is None:
-            print(f'No traces found', file=stderr)
-            return
-        output = stub.render()
-    print(output, file=stdout)
+        if stub is not None:
+            output = stub.render()
+    if output is None:
+        output, file = 'No traces found', stderr
+    print(output, file=file)
 
 
 def run_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,17 +37,7 @@ def func_anno(a: int, b: str) -> None:
     pass
 
 
-def func_anno2(
-    a: str,
-    b: str,
-) -> None:
-    pass
-
-
-def func_anno3(
-    a: str,
-    b: str,
-) -> None:
+def func_anno2(a: str, b: str) -> None:
     pass
 
 
@@ -112,27 +102,19 @@ def test_print_stub_ignore_existing_annotations(store_data, stdout, stderr):
     assert ret == 0
 
 
-def test_stub_diff(store_data, stdout, stderr):
+def test_get_diff(store_data, stdout, stderr):
     store, db_file = store_data
     traces = [
         CallTrace(func_anno, {'a': int, 'b': int}, int),
-        CallTrace(func_anno2, {'a': int, 'b': int}, int),
-        CallTrace(func_anno3, {'a': str, 'b': str}, None),
+        CallTrace(func_anno2, {'a': str, 'b': str}, None),
     ]
     store.add(traces)
     with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
-        ret = cli.main(['stub', func.__module__, '--diff'],
-                       stdout, stderr)
+        ret = cli.main(['stub', func.__module__, '--diff'], stdout, stderr)
     expected = """- def func_anno(a: int, b: str) -> None: ...
 ?                          ^ -     ^^ ^
 + def func_anno(a: int, b: int) -> int: ...
 ?                          ^^      ^ ^
-
-
-- def func2(a: str, b: str) -> None: ...
-?              ^ -     ^ -     ^^ ^
-+ def func2(a: int, b: int) -> int: ...
-?              ^^      ^^      ^ ^
 """
     assert stdout.getvalue() == expected
     assert stderr.getvalue() == ''

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,16 @@ def func_anno2(a: str, b: str) -> None:
     pass
 
 
+def super_long_function_with_long_params(
+    long_param1: str,
+    long_param2: str,
+    long_param3: str,
+    long_param4: str,
+    long_param5: str,
+) -> None:
+    pass
+
+
 class LoudContextConfig(DefaultConfig):
     @contextmanager
     def cli_context(self, command: str) -> Iterator[None]:
@@ -115,6 +125,46 @@ def test_get_diff(store_data, stdout, stderr):
 ?                          ^ -     ^^ ^
 + def func_anno(a: int, b: int) -> int: ...
 ?                          ^^      ^ ^
+"""
+    assert stdout.getvalue() == expected
+    assert stderr.getvalue() == ''
+    assert ret == 0
+
+
+def test_get_diff2(store_data, stdout, stderr):
+    store, db_file = store_data
+    traces = [
+        CallTrace(super_long_function_with_long_params, {
+            'long_param1': str,
+            'long_param2': str,
+            'long_param3': int,
+            'long_param4': str,
+            'long_param5': int,
+        }, None),
+        CallTrace(func_anno, {'a': int, 'b': int}, int),
+    ]
+    store.add(traces)
+    with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
+        ret = cli.main(['stub', func.__module__, '--diff'], stdout, stderr)
+    expected = """- def func_anno(a: int, b: str) -> None: ...
+?                          ^ -     ^^ ^
++ def func_anno(a: int, b: int) -> int: ...
+?                          ^^      ^ ^
+
+
+  def super_long_function_with_long_params(
+      long_param1: str,
+      long_param2: str,
+-     long_param3: str,
+?                  ^ -
++     long_param3: int,
+?                  ^^
+      long_param4: str,
+-     long_param5: str
+?                  ^ -
++     long_param5: int
+?                  ^^
+  ) -> None: ...
 """
     assert stdout.getvalue() == expected
     assert stderr.getvalue() == ''

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,20 @@ def func_anno(a: int, b: str) -> None:
     pass
 
 
+def func_anno2(
+    a: str,
+    b: str,
+) -> None:
+    pass
+
+
+def func_anno3(
+    a: str,
+    b: str,
+) -> None:
+    pass
+
+
 class LoudContextConfig(DefaultConfig):
     @contextmanager
     def cli_context(self, command: str) -> Iterator[None]:
@@ -92,6 +106,33 @@ def test_print_stub_ignore_existing_annotations(store_data, stdout, stderr):
         ret = cli.main(['stub', func.__module__, '--ignore-existing-annotations'],
                        stdout, stderr)
     expected = """def func_anno(a: int, b: int) -> int: ...
+"""
+    assert stdout.getvalue() == expected
+    assert stderr.getvalue() == ''
+    assert ret == 0
+
+
+def test_stub_diff(store_data, stdout, stderr):
+    store, db_file = store_data
+    traces = [
+        CallTrace(func_anno, {'a': int, 'b': int}, int),
+        CallTrace(func_anno2, {'a': int, 'b': int}, int),
+        CallTrace(func_anno3, {'a': str, 'b': str}, None),
+    ]
+    store.add(traces)
+    with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
+        ret = cli.main(['stub', func.__module__, '--diff'],
+                       stdout, stderr)
+    expected = """- def func_anno(a: int, b: str) -> None: ...
+?                          ^ -     ^^ ^
++ def func_anno(a: int, b: int) -> int: ...
+?                          ^^      ^ ^
+
+
+- def func2(a: str, b: str) -> None: ...
+?              ^ -     ^ -     ^^ ^
++ def func2(a: int, b: int) -> int: ...
+?              ^^      ^^      ^ ^
 """
     assert stdout.getvalue() == expected
     assert stderr.getvalue() == ''


### PR DESCRIPTION
This implements issue #58. [`difflib.ndiff`](https://docs.python.org/2/library/difflib.html#difflib.ndiff) is used. In the current implementation, only stubs that differ are shown to users. 

Demo:
```python
def func_anno(a: int, b: str) -> None:
    pass
def func_anno2(a: str, b: str) -> None:
    pass
```
Two traces: 

` CallTrace(func_anno, {'a': int, 'b': int}, int)` <- different from the existing annotation
` CallTrace(func_anno2, {'a': str, 'b': str}, None)`

Output:

```
- def func_anno(a: int, b: str) -> None: ...
?                          ^ -     ^^ ^
+ def func_anno(a: int, b: int) -> int: ...
?                          ^^      ^ ^
```

Demo 2:
```python
def func_anno(a: int, b: str) -> None:
    pass

def super_long_function_with_long_params(
    long_param1: str,
    long_param2: str,
    long_param3: str,
    long_param4: str,
    long_param5: str,
) -> None:
    pass
```
Traces
```
CallTrace(super_long_function_with_long_params, {
    'long_param1': str,
    'long_param2': str,
    'long_param3': int,  <- different
    'long_param4': str,
    'long_param5': int,  <- different
}, None),
CallTrace(func_anno, {'a': int, 'b': int}, int) <-different
```

Output:
```
- def func_anno(a: int, b: str) -> None: ...
?                          ^ -     ^^ ^
+ def func_anno(a: int, b: int) -> int: ...
?                          ^^      ^ ^


  def super_long_function_with_long_params(
      long_param1: str,
      long_param2: str,
-     long_param3: str,
?                  ^ -
+     long_param3: int,
?                  ^^
      long_param4: str,
-     long_param5: str
?                  ^ -
+     long_param5: int
?                  ^^
  ) -> None: ...
```

Please let me know if there is anything need to improve, revise, or delete. I appreciate your review.