### PR TITLE
Make sure we only rewrite typing module types

### DIFF
--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -145,6 +145,8 @@ class TypeRewriter:
         return typ
 
     def rewrite(self, typ):
+        if typ.__module__ != 'typing':
+            return self.generic_rewrite(typ)
         if isinstance(typ, _Any):
             typname = 'Any'
         elif isinstance(typ, _Union):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -20,6 +20,7 @@ import pytest
 
 from monkeytype.typing import (
     NoneType,
+    TypeRewriter,
     RemoveEmptyContainers,
     RewriteConfigDict,
     RewriteLargeUnion,
@@ -124,6 +125,15 @@ class TestRemoveEmptyContainers:
     def test_rewrite(self, typ, expected):
         rewritten = RemoveEmptyContainers().rewrite(typ)
         assert rewritten == expected
+
+
+class TestRewriteNameCollision:
+    def test_rewrite(self):
+        class List:
+            pass
+
+        rewritten = TypeRewriter().rewrite(List)
+        assert rewritten == List
 
 
 class TestRewriteConfigDict:


### PR DESCRIPTION
I hit this bug working on a project that uses the ast module. MonkeyType was trying to treat `ast.List` like `typing.List`. And I guess you can't assume *any* of those modules are uniquely named anyways. So add a check to make sure we're looking at the typing module.