### PR TITLE
The minimum changes to allow __main__ modules to be typed. #68

### DIFF
--- a/monkeytype/db/base.py
+++ b/monkeytype/db/base.py
@@ -71,7 +71,8 @@ class CallTraceStoreLogger(CallTraceLogger):
         self.traces: List[CallTrace] = []
 
     def log(self, trace: CallTrace) -> None:
-        self.traces.append(trace)
+        if not trace.func.__qualname__.startwith('__main__'):
+            self.traces.append(trace)
 
     def flush(self) -> None:
         self.store.add(self.traces)

--- a/monkeytype/db/base.py
+++ b/monkeytype/db/base.py
@@ -71,7 +71,7 @@ class CallTraceStoreLogger(CallTraceLogger):
         self.traces: List[CallTrace] = []
 
     def log(self, trace: CallTrace) -> None:
-        if not trace.func.__qualname__.startwith('__main__'):
+        if not trace.func.__module__ == '__main__':
             self.traces.append(trace)
 
     def flush(self) -> None:

--- a/monkeytype/tracing.py
+++ b/monkeytype/tracing.py
@@ -247,7 +247,6 @@ class CallTracer:
         code = frame.f_code
         if (
             event not in SUPPORTED_EVENTS or
-            frame.f_globals.get('__name__') == '__main__' or
             code.co_name == 'trace_types' or
             self.should_trace and not self.should_trace(code)
         ):

--- a/tests/db/test_base.py
+++ b/tests/db/test_base.py
@@ -10,7 +10,7 @@ from monkeytype.db.base import CallTraceStoreLogger
 from monkeytype.db.sqlite import (
     create_call_trace_table,
     SQLiteStore,
-    )
+)
 from monkeytype.tracing import trace_calls
 from _pytest.monkeypatch import MonkeyPatch
 
@@ -26,11 +26,13 @@ def func2(a, b):
 def func3(a, b):
     pass
 
+
 @pytest.fixture
 def logger() -> CallTraceStoreLogger:
     conn = sqlite3.connect(':memory:')
     create_call_trace_table(conn)
     return CallTraceStoreLogger(SQLiteStore(conn))
+
 
 def test_round_trip(logger):
     from types import ModuleType
@@ -49,23 +51,3 @@ def test_round_trip(logger):
 
     assert len(logger.store.filter('__main__')) == 0
     assert len(logger.store.filter(func.__module__)) == 2
-
-
-
-# def test_main_logging(logger):
-#     """Prefix match on qualname"""
-#     from types import ModuleType
-#     module = ModuleType('__main__')
-#     module.func = func
-#     MonkeyPatch().setattr(module.func, '__module__', '__main__', raising=False)
-#
-#     assert module.func.__module__ == '__main__'
-#
-#     traces = [
-#         CallTrace(func, {'a': int, 'b': str}, None),
-#         CallTrace(func2, {'a': int, 'b': int}, None),
-#         CallTrace(module.func, {'a': int, 'b': int}, None),
-#     ]
-#     store.add(traces)
-#     assert store.filter('__main__') == 0
-#     assert len(store.filter(func.__module__)) == 2

--- a/tests/db/test_base.py
+++ b/tests/db/test_base.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+import sqlite3
+
+from monkeytype.db.base import CallTraceStoreLogger
+from monkeytype.db.sqlite import (
+    create_call_trace_table,
+    SQLiteStore,
+    )
+from monkeytype.tracing import trace_calls
+from _pytest.monkeypatch import MonkeyPatch
+
+
+def func(a, b):
+    pass
+
+
+def func2(a, b):
+    pass
+
+
+def func3(a, b):
+    pass
+
+@pytest.fixture
+def logger() -> CallTraceStoreLogger:
+    conn = sqlite3.connect(':memory:')
+    create_call_trace_table(conn)
+    return CallTraceStoreLogger(SQLiteStore(conn))
+
+def test_round_trip(logger):
+    from types import ModuleType
+    module = ModuleType('__main__')
+    module.func = func3
+    MonkeyPatch().setattr(module.func, '__module__', '__main__', raising=False)
+    assert module.func.__module__ == '__main__'
+
+    with trace_calls(logger):
+        module.func(int, str)
+        assert len(logger.traces) == 0
+        func(int, str)
+        assert len(logger.traces) == 1
+        func2(int, str)
+        assert len(logger.traces) == 2
+
+    assert len(logger.store.filter('__main__')) == 0
+    assert len(logger.store.filter(func.__module__)) == 2
+
+
+
+# def test_main_logging(logger):
+#     """Prefix match on qualname"""
+#     from types import ModuleType
+#     module = ModuleType('__main__')
+#     module.func = func
+#     MonkeyPatch().setattr(module.func, '__module__', '__main__', raising=False)
+#
+#     assert module.func.__module__ == '__main__'
+#
+#     traces = [
+#         CallTrace(func, {'a': int, 'b': str}, None),
+#         CallTrace(func2, {'a': int, 'b': int}, None),
+#         CallTrace(module.func, {'a': int, 'b': int}, None),
+#     ]
+#     store.add(traces)
+#     assert store.filter('__main__') == 0
+#     assert len(store.filter(func.__module__)) == 2


### PR DESCRIPTION
This commit moves the filtering logic for __main__ modules to the CallTraceStoreLogger.  @carljm is this what you were thinking?

All of the current tests are passing locally for me and it is back to working order in IPython.  If this is in the right direction I'll start ticking off the contribution guidelines requirements.