### PR TITLE
Correctly handle spaces when applying stubs via retype

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -144,14 +144,14 @@ def apply_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None
         pyi_path = os.path.join(pyi_dir, pyi_name)
         with open(pyi_path, 'w+') as f:
             f.write(stub.render())
-        cmd = ' '.join([
+        retype_args = [
             'retype',
-            '--pyi-dir ' + pyi_dir,
-            '--target-dir ' + src_dir,
+            '--pyi-dir', pyi_dir,
+            '--target-dir', src_dir,
             src_path
-        ])
+        ]
         try:
-            proc = subprocess.run(cmd, shell=True, check=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+            proc = subprocess.run(retype_args, check=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
             print(proc.stdout.decode('utf-8'), file=stdout)
         except subprocess.CalledProcessError as cpe:
             raise HandlerError(f"Failed applying stub with retype:\n{cpe.stdout.decode('utf-8')}")


### PR DESCRIPTION
Don't use shell mode when invoking retype. Previously, we weren't
escaping spaces in filenames when invoking retype. By passing an
argument list to `subprocess.run` we allow it to take care of
properly escaping arguments.

Fixes #77