### PR TITLE
Fix issue with passing monkeytype cli flags to module

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -203,11 +203,10 @@ def run_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:
     old_argv = sys.argv.copy()
     try:
         with trace(args.config):
+            sys.argv = [args.script_path] + args.script_args
             if args.m:
-                sys.argv = sys.argv[3:]
                 runpy.run_module(args.script_path, run_name='__main__', alter_sys=True)
             else:
-                sys.argv = sys.argv[2:]
                 runpy.run_path(args.script_path, run_name='__main__')
     finally:
         sys.argv = old_argv


### PR DESCRIPTION
When specifying a custom configuration (or using any other command line flag), `sys.argv` is not correct for the script being run:

test.py:
```python
import sys
print(sys.argv)
```

```
> monkeytype -c sample.monkeytype_config:CONFIG run test.py
['test.py', 'run', 'test.py']
```

This fix modifies `sys.argv` based on argument parsing, rather than a hard-coded value.