### PR TITLE
Fix error when no module exist (#90)

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -191,9 +191,6 @@ def print_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None
 def list_modules_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None:
     output, file = None, stdout
     modules = args.config.trace_store().list_modules()
-    if not modules:
-        complain_about_no_traces(args, stderr)
-        return
     output = '\n'.join(modules)
     print(output, file=file)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,6 +209,17 @@ def test_display_list_of_modules(store_data, stdout, stderr):
     assert ret == 0
 
 
+def test_display_list_of_modules_no_modules(store_data, stdout, stderr):
+    store, db_file = store_data
+    with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
+        ret = cli.main(['list-modules'], stdout, stderr)
+    expected = ""
+    assert stderr.getvalue() == expected
+    expected = "\n"
+    assert stdout.getvalue() == expected
+    assert ret == 0
+
+
 def test_display_sample_count(capsys, stderr):
     traces = [
         CallTrace(func, {'a': int, 'b': str}, NoneType),


### PR DESCRIPTION
Issue #90 

The error arises because `module_path` used in `complain_about_no_traces` is only added for `stub_parser` and `apply_parser` these two but not the `list_module_parser`.

See: 

https://github.com/Instagram/MonkeyType/blob/629d63d8abe6b0c07750e6dd17a71a809e196370/monkeytype/cli.py#L64-L69

https://github.com/Instagram/MonkeyType/blob/629d63d8abe6b0c07750e6dd17a71a809e196370/monkeytype/cli.py#L293-L302

https://github.com/Instagram/MonkeyType/blob/629d63d8abe6b0c07750e6dd17a71a809e196370/monkeytype/cli.py#L315-L324