### PR TITLE
Pass --incremental to retype, partial annotation is OK.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 master
 ------
 
+* Pass ``--incremental`` to retype when applying stubs, so it doesn't choke on
+  partial stubs (which can result from e.g. failures to decode some traces).
+
 19.1.0
 ------
 

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -151,6 +151,7 @@ def apply_stub_handler(args: argparse.Namespace, stdout: IO, stderr: IO) -> None
             f.write(stub.render())
         retype_args = [
             'retype',
+            '--incremental',
             '--pyi-dir', pyi_dir,
             '--target-dir', src_dir,
             src_path


### PR DESCRIPTION
Sometimes due to a failure decoding traces we have a partially-annotated function in stubs. There's no benefit in retype choking on that, just go ahead and apply what you know.