### PR TITLE
Don't put stringified annotations in stubs

### DIFF
--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -360,6 +360,8 @@ def render_annotation(anno: Any) -> str:
             rendered = anno.__qualname__
         else:
             rendered = anno.__module__ + '.' + anno.__qualname__
+    elif isinstance(anno, str):
+        rendered = anno
     else:
         rendered = repr(anno)
 


### PR DESCRIPTION
This is not only unnecessary in stubs but also partially fixes #147 as existing annotations are no longer treated all as string literals.

[Depends on #145 and #146, ignore the first two commits]