### PR TITLE
Allow for importing modules instead of bare types

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -28,6 +28,7 @@ from monkeytype.config import Config
 from monkeytype.exceptions import MonkeyTypeError
 from monkeytype.stubs import (
     ExistingAnnotationStrategy,
+    ImportStrategy,
     Stub,
     build_module_stubs_from_traces,
 )
@@ -124,6 +125,7 @@ def get_stub(args: argparse.Namespace, stdout: IO, stderr: IO) -> Optional[Stub]
     stubs = build_module_stubs_from_traces(
         traces,
         existing_annotation_strategy=args.existing_annotation_strategy,
+        import_strategy=args.import_strategy,
         rewriter=rewriter,
     )
     if args.sample_count:
@@ -300,6 +302,14 @@ qualname format.""")
         default=False,
         help='Print to stderr the numbers of traces stubs are based on'
         )
+    apply_parser.add_argument(
+        "--import-modules",
+        action='store_const',
+        dest='import_strategy',
+        default=ImportStrategy.TYPES,
+        const=ImportStrategy.MODULES,
+        help="Don't import types directly, just modules.",
+        )
     apply_parser.set_defaults(handler=apply_stub_handler)
 
     stub_parser = subparsers.add_parser(
@@ -338,6 +348,14 @@ qualname format.""")
         default=ExistingAnnotationStrategy.REPLICATE,
         const=ExistingAnnotationStrategy.OMIT,
         help='Omit from stub any existing annotations in source. Implied by --apply.',
+        )
+    stub_parser.add_argument(
+        "--import-modules",
+        action='store_const',
+        dest='import_strategy',
+        default=ImportStrategy.TYPES,
+        const=ImportStrategy.MODULES,
+        help="Don't import types directly, just modules.",
         )
     stub_parser.add_argument(
         "--diff",


### PR DESCRIPTION
Some projects, EdgeDB in particular, avoid importing bare names to avoid
conflicts.  Instead, they rely on importing modules and addressing type names
with a proper module or subpackage prefix.

This change provides a `--import-modules` CLI option that changes the default
behavior from:
```py3
  from package.subpackage import SomeType

  def func(arg: SomeType) -> None: ...
```
into:
```py3
  from package import subpackage

  def func(arg: subpackage.SomeType) -> None: ...
```
This change leaves imports from top-level modules alone, so for example `from
typing import List` stays as it was.  This can be further refined if needed.

[Depends on #145, #146, #148; ignore the first three commits please]