### PR TITLE
Handle empty tuples consistently. Fixes #136.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 master
 ------
 
+* Fix crash with empty tuples. Thanks akayunov for the report, Christophe
+  Simonis for the simplest-case repro. Fixes #136.
+
 * Don't add stringified annotations to type stubs. Thanks Łukasz Langa. Merge
   of #148.
 

--- a/monkeytype/encoding.py
+++ b/monkeytype/encoding.py
@@ -70,6 +70,10 @@ def type_to_dict(typ: type) -> TypeDict:
     }
     elem_types = getattr(typ, '__args__', None)
     if elem_types and is_generic(typ):
+        # empty typing.Tuple is weird; the spec says it should be Tuple[()],
+        # which results in __args__ of `((),)`
+        if elem_types == ((),):
+            elem_types = ()
         d['elem_types'] = [type_to_dict(t) for t in elem_types]
     return d
 
@@ -104,7 +108,7 @@ def type_from_dict(d: TypeDict) -> type:
             f"is of type {type(typ)}, not type."
         )
     elem_type_dicts = d.get('elem_types')
-    if elem_type_dicts and is_generic(typ):
+    if elem_type_dicts is not None and is_generic(typ):
         elem_types = tuple(type_from_dict(e) for e in elem_type_dicts)
         # mypy complains that a value of type `type` isn't indexable. That's
         # true, but we know typ is a subtype that is indexable. Even checking

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -57,6 +57,8 @@ class TestTypeConversion:
             Optional[str],
             Set[int],
             Tuple[int, str, str],
+            Tuple,  # unparameterized tuple
+            Tuple[()],  # empty tuple
             Type[Outer],
             Union[Outer.Inner, str, None],
             # Nested generics

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -74,7 +74,7 @@ class TestGetType:
             ([1, True], List[Union[int, bool]]),
             ({'a': 1, 'b': 2}, Dict[str, int]),
             ({'a': 1, 2: 'b'}, Dict[Union[str, int], Union[str, int]]),
-            (tuple(), typing_Tuple),
+            (tuple(), typing_Tuple[()]),
             (helper, Callable),
             (lambda x: x, Callable),
             (Dummy().an_instance_method, Callable),
@@ -128,6 +128,7 @@ class TestRemoveEmptyContainers:
             (Dict[str, Union[List[str], List[Any]]], Dict[str, List[str]]),
             (Union[List[Any], Set[Any]], Union[List[Any], Set[Any]]),
             (Tuple, Tuple),
+            (typing_Tuple[()], typing_Tuple[()]),
         ],
     )
     def test_rewrite(self, typ, expected):


### PR DESCRIPTION
It has now been documented (most recently in
https://bugs.python.org/issue37814) that the correct way to annotate an
empty tuple is `Tuple[()]`.

The runtime behavior of such an annotation is perhaps slightly
unexpected, in that `Tuple[()].__args__ == ((),)`, rather than `()` as
you might expect it would be (to parallel e.g. `Tuple[int, str].__args__
== (int, str)`).

On the other hand, this oddity is "useful" in that `Tuple.__args__ ==
()`, so this allows us to distinguish at runtime un-subscripted `Tuple`
(which I think must be interpreted as implicitly `Tuple[Any,...]` to
parallel e.g. `List` being equivalent to `List[Any]`?) from `Tuple[()]`.

This pull request makes MonkeyType's handling of tuple types consistent,
in that `Tuple` will round-trip to `Tuple` and `Tuple[()]` to
`Tuple[()]`, and in so doing fixes the crash with empty tuples in
rewriters exposed in #136. A traced empty tuple will now be correctly
represented in stubs as `Tuple[()]`.