### PR TITLE
Typing support for collections.defaultdict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ master
   https://bugs.python.org/issue30220. Thanks Daniel G Holmes for the report.
   Merge of #142, fixes #141.
 
+* Typing support for collections.defaultdict
 
 19.5.0
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ master
   https://bugs.python.org/issue30220. Thanks Daniel G Holmes for the report.
   Merge of #142, fixes #141.
 
-* Typing support for collections.defaultdict
+* Typing support for collections.defaultdict. Thanks Dinesh Kesavan. Merge of #152.
 
 19.5.0
 ------

--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -3,12 +3,14 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from collections import defaultdict
 import inspect
 import types
 from typing import (
     Any,
     Callable,
     Dict,
+    DefaultDict,
     Generator,
     Iterable,
     Iterator,
@@ -143,6 +145,10 @@ def get_type(obj, max_typed_dict_size=None):
         return Set[elem_type]
     elif typ is dict:
         return get_dict_type(obj, max_typed_dict_size)
+    elif typ is defaultdict:
+        key_type = shrink_types(get_type(k) for k in obj.keys())
+        val_type = shrink_types(get_type(v) for v in obj.values())
+        return DefaultDict[key_type, val_type]
     elif typ is tuple:
         return Tuple[tuple(get_type(e) for e in obj)]
     return typ

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -3,9 +3,11 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from collections import defaultdict
 from typing import (
     Any,
     Callable,
+    DefaultDict,
     Dict,
     Iterator,
     List,
@@ -198,7 +200,20 @@ def generator() -> Iterator[int]:
     yield 1
 
 
+def get_default_dict(key, value):
+    m = defaultdict(lambda: 1)
+    m[key] += value
+    return m
+
+
+def get_nested_default_dict(key, value):
+    m = defaultdict(lambda: defaultdict(lambda: 1))
+    m[key][key] += value
+    return m
+
+
 class TestGetType:
+
     @pytest.mark.parametrize(
         'value, expected_type',
         [
@@ -233,6 +248,8 @@ class TestGetType:
             ({'a': 1, 'b': 2}, 2, TypedDict(DUMMY_TYPED_DICT_NAME, {'a': int, 'b': int})),
             ({'a': 1, 'b': 2}, 1, Dict[str, int]),
             ({'a': 1, 2: 'b'}, None, Dict[Union[str, int], Union[str, int]]),
+            (get_default_dict(key=1, value=1), None, DefaultDict[int, int]),
+            (get_nested_default_dict(key=1, value=1.0), None, DefaultDict[int, DefaultDict[int, float]]),
         ],
     )
     def test_dict_type(self, value, max_typed_dict_size, expected_dict_type):


### PR DESCRIPTION
This change will allow instance of collections.defaultdict to be typed as typing.DefaultDict, currently they are typed as collections.defaultdict. Type of Key and Value are determined similar to the way it is determined for Dict.

This is my first time creating a pull request. 

Please let me know if you have comments or would like me to make any changes.