### PR TITLE
add missing depedencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         ]
     },
     python_requires='>=3.6',
-    install_requires=['retype'],
+    install_requires=['mypy_extensions', 'retype', 'stringcase'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Congratulations on the release, and thanks for MonkeyType!

Looks like there are more typeddicts (yay!) and more consistent casing (yay!), but those libraries weren't added to the dependencies (boo!).

Adding a thorough test, i suppose, would require doing a non-pipenv install of the library during CI... but ~~happy to add if so desired~~.

c/f https://github.com/conda-forge/monkeytype-feedstock/pull/11