### PR TITLE
Disable TypedDict generation by default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 master
 ------
 
+* Disable TypedDict generation by default for now, since it breaks `--apply`.
+
 
 19.11.1
 -------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -114,7 +114,10 @@ Subclassing ``Config`` or ``DefaultConfig``
    `TypedDict` will be emitted instead of `Dict`. Return `0` to disable per-key
    type tracking and TypedDict generation.
 
-   Defaults to 10.
+   Currently TypedDict generation in stubs breaks `--apply` because retype
+   doesn't support copying new TypedDict subclasses from stub to code.
+
+   Defaults to 0.
 
 .. class:: DefaultConfig()
 

--- a/monkeytype/config.py
+++ b/monkeytype/config.py
@@ -87,7 +87,7 @@ class Config(metaclass=ABCMeta):
 
     def max_typed_dict_size(self) -> int:
         """Size up to which a dictionary will be traced as a TypedDict."""
-        return 10
+        return 0
 
 
 lib_paths = {sysconfig.get_path(n) for n in ['stdlib', 'purelib', 'platlib']}


### PR DESCRIPTION
Generating new TypedDict subclasses in stubs breaks `--apply` because retype doesn't support moving these over to the code. Disable this feature by default (but leave it available via config for those who wish to enable it), at least for now until we can resolve that issue.