### PR TITLE
Import Optional if default param is None to match renderer

### DIFF
--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -154,6 +154,8 @@ def get_imports_for_signature(sig: inspect.Signature) -> ImportMap:
     imports = ImportMap()
     for param in sig.parameters.values():
         param_imports = get_imports_for_annotation(param.annotation)
+        if not _is_optional(param.annotation) and param.default is None:
+            imports['typing'].add('Optional')
         imports.merge(param_imports)
     return_imports = get_imports_for_annotation(sig.return_annotation)
     imports.merge(return_imports)

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -40,6 +40,7 @@ from monkeytype.stubs import (
     StubIndexBuilder,
     build_module_stubs,
     get_imports_for_annotation,
+    get_imports_for_signature,
     render_signature,
     shrink_traced_types,
     update_signature_args,
@@ -978,3 +979,10 @@ class TestGetImportsForAnnotation:
 
     def test_nested_class(self):
         assert get_imports_for_annotation(Parent.Child) == {Parent.__module__: {'Parent'}}
+
+
+class TestGetImportsForSignature:
+    def test_default_none_parameter_imports(self):
+        stub = FunctionStub('test', inspect.signature(default_none_parameter), FunctionKind.MODULE)
+        expected = {'typing': {'Optional'}}
+        assert get_imports_for_signature(stub.signature) == expected


### PR DESCRIPTION
Fixes #74 and relates to #76 

In `render_parameter` additional logic is used to wrap `Optional` around a type annotation. This add a type annotation without importing `Optional` from `typing`, so if `Optional` has not been imported yet this will raise errors. This patch adds that logic in `get_imports_for_signature` to prevent this error. 

https://github.com/Instagram/MonkeyType/blob/47a77b01dea96c409b391cb5062582cb515ef571/monkeytype/stubs.py#L337