### PR TITLE
Fix an example of CallTracer

### DIFF
--- a/doc/tracing.rst
+++ b/doc/tracing.rst
@@ -89,6 +89,7 @@ If you have a config, you can easily pull those from it::
   logger = my_config.trace_logger()
   tracer = CallTracer(
       logger=logger,
+      max_typed_dict_size=my_config.max_typed_dict_size(),
       code_filter=my_config.code_filter(),
       sample_rate=my_config.sample_rate(),
   )


### PR DESCRIPTION
An example of `CallTracer` seems does not reflect newly added positional argument (missing `max_typed_dict_size`)

https://github.com/Instagram/MonkeyType/blob/56a688efccedd66521542144cd0afa4dc1e5e562/monkeytype/tracing.py#L190-L196