### PR TITLE
The README file in this repo has a bad link - [404:NotFound]  - "stub files"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ stub files directly to your code.
 .. _pip: https://pip.pypa.io/en/stable/
 .. _libcst: https://pypi.python.org/pypi/libcst
 .. _sys.setprofile: https://docs.python.org/3/library/sys.html#sys.setprofile
-.. _stub files: http://mypy.readthedocs.io/en/latest/basics.html#library-stubs-and-the-typeshed-repo
+.. _stub files: https://mypy.readthedocs.io/en/latest/getting_started.html#library-stubs-and-typeshed
 
 .. end-here
 


### PR DESCRIPTION
The markup version of the readme that is displayed for the main page in this repo contains the following bad link:

"stub files"
Status code [404:NotFound] - Link: http://mypy.readthedocs.io/en/latest/basics.html#library-stubs-and-the-typeshed-repo

As per info here: https://github.com/python/mypy/issues/4851#issuecomment-399333461

This link has moved and is now: https://mypy.readthedocs.io/en/latest/getting_started.html#library-stubs-and-typeshed


**Extra**
This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

Re-check this Repo using the tool’s website: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fInstagram%2fMonkeyType

If this has been helpful, or if you have any feedback on the tool itself, then please feel free to share your thoughts by adding a comment here, or adding to a “Discussion” in the tool’s Repo.