### PR TITLE
Update `requirements.txt`

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,4 @@
-attrs==17.4.0
+attrs==19.2.0
 black==18.4a2
 click==6.7
 coverage==4.5.1
@@ -7,13 +7,13 @@ flake8==3.5.0
 mccabe==0.6.1
 MonkeyType==18.8.0
 more-itertools==4.1.0
-mypy==0.590
-pluggy==0.6.0
-py==1.5.3
+mypy==0.761
+pluggy==0.13.0
+py==1.10.0
 pycodestyle==2.3.1
 pyflakes==1.6.0
-pytest==3.5.0
+pytest==6.0.2
 pytest-cov==2.5.1
 retype==17.12.0
 six==1.11.0
-typed-ast==1.1.0
+typed-ast==1.4.0


### PR DESCRIPTION
I wasn't able to run the MonkeyType demos on my machine because of a missing header file in `typed_ast`. This is a [known issue](https://github.com/python/typed_ast/issues/97) that can be fixed with an updated version of the package. (I'm using CPython, and it was still an issue for me, even though the original poster is using PyPy.) Then, to support the new version of `typed_ast`, I  [updated `mypy`](https://github.com/python/typed_ast/issues/124). Finally, I fixed some additional warnings by updating other packages.

Test plan: The "Quickstart" guide in `demo/README.md` can be completed successfully