### PR TITLE
Add caller column into stub

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 main
 ----
 
+* Add caller column into stubs so that you can see where the function got called.
+
 * Drop Python 3.6 support.
 
 * Fix `AttributeError: __args__` when generating stubs on Python 3.9. Thanks

--- a/doc/stores.rst
+++ b/doc/stores.rst
@@ -154,6 +154,11 @@ choose to implement its own alternative (de)serialization.
     A JSON-serialized representation of the actual yield type for this traced
     call, or ``None`` if this call did not yield (i.e. returned instead).
 
+  .. attribute:: caller: Optional[type]
+
+    The ``caller`` of the traced function or method contains filename, module, and line number information.
+
+
 .. currentmodule:: monkeytype.db.base
 
 CallTraceThunk

--- a/doc/tracing.rst
+++ b/doc/tracing.rst
@@ -178,7 +178,7 @@ method saves all collected traces to the given ``store``.
 CallTrace
 '''''''''
 
-.. class:: CallTrace(func: Callable, arg_types: Dict[str, type], return_type: Optional[type] = None, yield_type: Optional[type] = None)
+.. class:: CallTrace(func: Callable, arg_types: Dict[str, type], return_type: Optional[type] = None, yield_type: Optional[type] = None, caller: Optional[str] = None)
 
   Type information for one traced call of one function.
 
@@ -202,3 +202,7 @@ CallTrace
   .. attribute:: yield_type: Optional[type]
 
     Type yielded by this call, or ``None`` if this call did not yield.
+
+  .. attribute:: caller: Optional[type]
+
+    The filename, module, and line number information that executes function where the trace occurred.

--- a/monkeytype/encoding.py
+++ b/monkeytype/encoding.py
@@ -195,13 +195,15 @@ class CallTraceRow(CallTraceThunk):
         qualname: str,
         arg_types: str,
         return_type: Optional[str],
-        yield_type: Optional[str]
+        yield_type: Optional[str],
+        caller: Optional[str]
     ) -> None:
         self.module = module
         self.qualname = qualname
         self.arg_types = arg_types
         self.return_type = return_type
         self.yield_type = yield_type
+        self.caller = caller
 
     @classmethod
     def from_trace(cls: Type[CallTraceRowT], trace: CallTrace) -> CallTraceRowT:
@@ -210,14 +212,15 @@ class CallTraceRow(CallTraceThunk):
         arg_types = arg_types_to_json(trace.arg_types)
         return_type = maybe_encode_type(type_to_json, trace.return_type)
         yield_type = maybe_encode_type(type_to_json, trace.yield_type)
-        return cls(module, qualname, arg_types, return_type, yield_type)
+        caller = trace.caller
+        return cls(module, qualname, arg_types, return_type, yield_type, caller)
 
     def to_trace(self) -> CallTrace:
         function = get_func_in_module(self.module, self.qualname)
         arg_types = arg_types_from_json(self.arg_types)
         return_type = maybe_decode_type(type_from_json, self.return_type)
         yield_type = maybe_decode_type(type_from_json, self.yield_type)
-        return CallTrace(function, arg_types, return_type, yield_type)
+        return CallTrace(function, arg_types, return_type, yield_type, self.caller)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, CallTraceRow):
@@ -227,12 +230,14 @@ class CallTraceRow(CallTraceThunk):
                 self.arg_types,
                 self.return_type,
                 self.yield_type,
+                self.caller,
             ) == (
                 other.module,
                 other.qualname,
                 other.arg_types,
                 other.return_type,
                 other.yield_type,
+                other.caller,
             )
         return NotImplemented
 


### PR DESCRIPTION
## What this pr does

- add caller column into stub

## Why I do this

If you have a code like this.

```python
# File: main.py
import a
import b


# File: a.py
from test import return_str
print(return_str(15, 10))


# File: b.py
from test import return_str
print(return_str("a", "b"))


# File: test.py
def return_str(a, b):  # return_str expects only accepting str.
    return a, b
```

This generates stub like below.

```tsv
created_at	module	qualname	arg_types	return_type	yield_type
2021-10-03 15:51:45.214250	test	return_str	{"a": {"module": "builtins", "qualname": "int"}, "b": {"module": "builtins", "qualname": "int"}}	{"elem_types": [{"module": "builtins", "qualname": "int"}, {"module": "builtins", "qualname": "int"}], "module": "typing", "qualname": "Tuple"}
2021-10-03 15:51:45.214287	test	return_str	{"a": {"module": "builtins", "qualname": "str"}, "b": {"module": "builtins", "qualname": "str"}}	{"elem_types": [{"module": "builtins", "qualname": "str"}, {"module": "builtins", "qualname": "str"}], "module": "typing", "qualname": "Tuple"}
```

Then you'll notice there is some frame is calling return_str with int arguments which is wrong. You want to find where this calls, but you can't see any information about where that is. So you need to delete the wrong stub, apply the stub, run mypy and find where that happens.

By this PR, you can find where to fix by once.

```tsv
created_at	module	qualname	arg_types	return_type	yield_type	caller
2021-10-03 15:51:45.214250	test	tmp	{"a": {"module": "builtins", "qualname": "int"}, "b": {"module": "builtins", "qualname": "int"}}	{"elem_types": [{"module": "builtins", "qualname": "int"}, {"module": "builtins", "qualname": "int"}], "module": "typing", "qualname": "Tuple"}		${filename}/a.py:${module-name(if you run in top module, this doesn't show up.):}2
2021-10-03 15:51:45.214287	test	tmp	{"a": {"module": "builtins", "qualname": "str"}, "b": {"module": "builtins", "qualname": "str"}}	{"elem_types": [{"module": "builtins", "qualname": "str"}, {"module": "builtins", "qualname": "str"}], "module": "typing", "qualname": "Tuple"}		${filename}/b.py:${module-name(if you run in top module, this doesn't show up.):}2

```

As you see calling function with `(int, int)` arguments is happened at `"a.py:2"`.

## remarks

I submitted Contributor License Agreement.