### PR TITLE
Move canonical version directly into setup.cfg.

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -6,7 +6,7 @@ How to release MonkeyType
    digits of the current year, ``M`` is the current month (no leading zero, but
    might be two digits), and ``X`` just increments, starting at ``0`` for the first
    release in a month (can also be multiple digits if needed).
-2. Update ``monkeytype/__init__.py``: change ``__version__`` to the same
+2. Update ``setup.cfg``: change ``version`` to the same
    version as above.
 3. Commit these changes with the commit message "Version YY.M.X" (replacing with
    the real version).
@@ -16,6 +16,6 @@ How to release MonkeyType
 6. Upload the packages to PyPI:
    ``pipenv run twine upload -s dist/MonkeyType-YY.M.X-py3-none-any.whl dist/MonkeyType-YY.M.X.tar.gz``
 7. Add a new "main" heading to ``CHANGES.rst`` and bump the version number in
-   ``monkeytype/__init__.py`` to the next micro version, with ``.dev1`` appended
+   ``setup.cfg`` to the next micro version, with ``.dev1`` appended
    (e.g. after releasing ``18.5.1``, bump to ``18.5.2.dev1``). Commit this.
 8. Push everything to GitHub: ``git push && git push --tags``.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,10 +62,10 @@ author = 'Matt Page & Carl Meyer'
 # built documents.
 #
 
-with open(os.path.join(os.path.dirname(os.path.abspath('.')), 'monkeytype', '__init__.py')) as f:
+with open(os.path.join(os.path.dirname(os.path.abspath('.')), 'setup.cfg')) as f:
     for line in f:
-        if line.startswith('__version__ ='):
-            version_from_code = line.split('=')[1].strip().strip('"\'')
+        if line.startswith('version ='):
+            version_from_code = line.split('=')[1].strip()
 
 # The short X.Y version.
 version = '.'.join(version_from_code.split('.')[:3])

--- a/monkeytype/__init__.py
+++ b/monkeytype/__init__.py
@@ -8,8 +8,6 @@ from typing import ContextManager, Optional
 from monkeytype.config import Config, get_default_config
 from monkeytype.tracing import trace_calls
 
-__version__ = "22.2.0.dev1"
-
 
 def trace(config: Optional[Config] = None) -> ContextManager[None]:
     """Context manager to trace and log all calls.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = MonkeyType
-version = attr: monkeytype.__version__
+version = 22.2.0.dev1
 description = Generating type annotations from sampled production types
 long_description = file: README.rst, CHANGES.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Since the `attr:` feature of `setup.cfg` actually imports the module,
using it requires that all transitive dependencies of
`monkeytype/__init__.py` be importable, just in order to parse metadata.
This is unnecessary.