### PR TITLE
Use getattr with None to avoid AttributesError

### DIFF
--- a/monkeytype/compat.py
+++ b/monkeytype/compat.py
@@ -43,11 +43,19 @@ def is_generic_of(typ: Any, gen: Any) -> bool:
 
 
 def qualname_of_generic(typ: Any) -> str:
-    return str(typ._name or typ.__origin__._name or typ.__origin__.__qualname__)
+    return str(
+        getattr(typ, "_name", None)
+        or getattr(typ.__origin__, "_name", None)
+        or typ.__origin__.__qualname__
+    )
 
 
 def name_of_generic(typ: Any) -> str:
-    return str(typ._name or typ.__origin__._name or typ.__origin__.__name__)
+    return str(
+        getattr(typ, "_name", None)
+        or getattr(typ.__origin__, "_name", None)
+        or typ.__origin__.__name__
+    )
 
 
 def is_forward_ref(typ: Any) -> bool:


### PR DESCRIPTION
I got `AttributesError` for `IO` like below.

```
  File "/tmp/tmpvenv.CeMKc5V/lib/python3.8/site-packages/monkeytype/compat.py", line 40, in qualname_of_generic
    return typ._name or typ.__origin__._name or typ.__origin__.__qualname__
AttributeError: type object 'IO' has no attribute '_name'
```

It seems to me like `monkeytype.compat.qualname_of_generic` is intended to work even if `typ` doesn't have `_name`.
Why don't you use `getattr`?