### PR TITLE
Bump required libcst version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >= 3.7
 install_requires =
     mypy_extensions
     django-stubs
-    libcst>=0.3.7
+    libcst>=0.4.4
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
LibCST has seen a bunch of important fixes to apply type annotation and others that affect MonkeyType. For example https://github.com/Instagram/LibCST/issues/690 should be fixed now.

Note to reviewers: LibCST 0.4.0 and onwards comes with binary wheels, whereas before it was a pure python package.