### PR TITLE
docs: fix simple typo, heterogenous -> heterogeneous

### DIFF
--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -147,7 +147,7 @@ def shrink_types(types, max_typed_dict_size):
         return types[0]
 
     # If they are all lists, shrink their argument types. This way, we avoid
-    # rewriting heterogenous anonymous TypedDicts to Dict.
+    # rewriting heterogeneous anonymous TypedDicts to Dict.
     if all(is_list(typ) for typ in types):
         annotation = shrink_types(
             (getattr(typ, "__args__")[0] for typ in types), max_typed_dict_size


### PR DESCRIPTION
There is a small typo in monkeytype/typing.py.

Should read `heterogeneous` rather than `heterogenous`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md