### PR TITLE
[python 3.11] Handle upstream changes to `Tuple[()]`

### DIFF
--- a/monkeytype/encoding.py
+++ b/monkeytype/encoding.py
@@ -73,6 +73,9 @@ def type_to_dict(typ: type) -> TypeDict:
         "qualname": qualname,
     }
     elem_types = getattr(typ, "__args__", None)
+    # in Python 3.11, for Tuple[()] elem_types will be ()
+    if qualname == 'Tuple' and elem_types == ():
+        d["elem_types"] = []
     if elem_types and is_generic(typ):
         # empty typing.Tuple is weird; the spec says it should be Tuple[()],
         # which results in __args__ of `((),)`

--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -357,7 +357,7 @@ class RenderAnnotation(GenericTypeRewriter[str]):
         )
 
     def make_builtin_tuple(self, elements: Iterable[str]) -> str:
-        res = ', '.join(elements)
+        res = ", ".join(elements)
         return res if res else "()"
 
     def make_container_type(self, container_type: str, elements: str) -> str:
@@ -593,7 +593,9 @@ class ReplaceTypedDictsWithStubs(TypeRewriter):
         args = getattr(container, "__args__", None)
         if args is None:
             return container
-        elif args == ((),):  # special case of empty tuple `Tuple[()]`
+        elif args == ((),) or (
+            container.__qualname__ == "Tuple" and args == ()
+        ):  # special case of empty tuple `Tuple[()]`
             elems: Tuple[Any, ...] = ()
         else:
             # Avoid adding a suffix for the first one so that

--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -357,7 +357,8 @@ class RenderAnnotation(GenericTypeRewriter[str]):
         )
 
     def make_builtin_tuple(self, elements: Iterable[str]) -> str:
-        return ", ".join(elements) if elements else "()"
+        res = ', '.join(elements)
+        return res if res else "()"
 
     def make_container_type(self, container_type: str, elements: str) -> str:
         return f"{container_type}[{elements}]"


### PR DESCRIPTION
Upstream changes how `Tuple[()]` behaves in https://github.com/python/cpython/issues/91137: `__getattr__` now returns `()` instead of `((),)`. Change the code to handle that (but preserving the old code path for Python <= 3.10).

Fixes #272.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>