### PR TITLE
Add TypedDict FAQ, fix branch name in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ Pull Requests
 
 We welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation and ensure it builds
    (``cd doc && pipenv run make html``).

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -50,3 +50,25 @@ disable coverage measurement for that run, and vice versa.
 
 .. _coverage.py: https://coverage.readthedocs.io/
 .. _sys.setprofile: https://docs.python.org/3/library/sys.html#sys.setprofile
+
+MonkeyType stopped generating TypedDicts.
+-----------------------------------------
+
+Since 19.11.2 TypedDict generation is disabled by default.
+To enable it, create a config file ``monkeytype_config.py`` with the following content::
+
+    from monkeytype.config import DefaultConfig
+
+    class MyConfig(DefaultConfig):
+        ...
+        def max_typed_dict_size(self) -> int:
+            """
+            The maximum size of string-keyed dictionary for which per-key value types
+            will be stored, and (if the traced keys and value types are consistent),
+            a TypedDict will be emitted instead of Dict.
+            Return 0 to disable per-key type tracking and TypedDict generation.
+            """
+            return 10
+
+
+    CONFIG = MyConfig()


### PR DESCRIPTION
- Branch name is now `main` not `master`
- Add FAQ how to reenable generation of `TypedDict`s