### PR TITLE
Add "most common base" rewriter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 main
 ----
 
-* Add rewriter to replace union of derived classes with common
-  base class (not enabled by default)
+* Add ``RewriteMostSpecificCommonBase` type rewriter to replace union of derived classes with common
+  base class (not enabled by default.) Merge of #311, fixes #298. Thanks Christoph Hansknecht.
 
 * Drop support for Python 3.7.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 main
 ----
 
+* Add rewriter to replace union of derived classes with common
+  base class (not enabled by default)
+
 * Drop support for Python 3.7.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 main
 ----
 
-* Add ``RewriteMostSpecificCommonBase` type rewriter to replace union of derived classes with common
+* Add ``RewriteMostSpecificCommonBase`` type rewriter to replace union of derived classes with common
   base class (not enabled by default.) Merge of #311, fixes #298. Thanks Christoph Hansknecht.
 
 * Drop support for Python 3.7.

--- a/doc/generation.rst
+++ b/doc/generation.rst
@@ -171,6 +171,14 @@ are performed through configured type rewriters.
   type frequently occurs when a method that takes ``List[int]`` also sometimes
   receives the empty list, which will be typed as ``List[Any]``.
 
+.. class:: RewriteMostSpecificCommonBase()
+
+  Rewrites e.g. ``Union[Derived1, Derived2]`` to ``Base``, where
+  ``Derived1`` and ``Derived2`` are both subclasses of a common ``Base``.
+  Unions of arbitrarily many subclasses of a common base class are rewritten
+  as a single class, provided that multiple inherit does not occur in the
+  chain from derived classes to base class.
+
 .. class:: RewriteConfigDict()
 
   Takes a generated type like ``Union[Dict[K, V1], Dict[K, V2]]`` and rewrites

--- a/doc/generation.rst
+++ b/doc/generation.rst
@@ -176,7 +176,7 @@ are performed through configured type rewriters.
   Rewrites e.g. ``Union[Derived1, Derived2]`` to ``Base``, where
   ``Derived1`` and ``Derived2`` are both subclasses of a common ``Base``.
   Unions of arbitrarily many subclasses of a common base class are rewritten
-  as a single class, provided that multiple inherit does not occur in the
+  as a single class, provided that multiple inheritance does not occur in the
   chain from derived classes to base class.
 
 .. class:: RewriteConfigDict()

--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -531,17 +531,14 @@ class RewriteMostSpecificCommonBase(TypeRewriter):
             if len(curr_bases) != 1:
                 break
 
-            curr_base = curr_bases[0]
-            curr_klass = curr_base
+            curr_klass = curr_bases[0]
         return bases[::-1]
 
     def _merge_common_bases(self, first_bases, second_bases):
         merged_bases = []
 
         # Only process up to shorter of the lists
-        for first_base, second_base in zip(first_bases,
-                                           second_bases,
-                                           strict=False):
+        for first_base, second_base in zip(first_bases, second_bases, strict=False):
             if first_base is second_base:
                 merged_bases.append(second_base)
             else:
@@ -556,8 +553,6 @@ class RewriteMostSpecificCommonBase(TypeRewriter):
 
         for klass in klasses:
             base = self._compute_bases(klass)
-            if base is None:
-                return union
             bases.append(base)
 
         common_bases = functools.reduce(self._merge_common_bases, bases)

--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -538,7 +538,7 @@ class RewriteMostSpecificCommonBase(TypeRewriter):
         merged_bases = []
 
         # Only process up to shorter of the lists
-        for first_base, second_base in zip(first_bases, second_bases, strict=False):
+        for first_base, second_base in zip(first_bases, second_bases):
             if first_base is second_base:
                 merged_bases.append(second_base)
             else:

--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -504,20 +504,23 @@ class RewriteGenerator(TypeRewriter):
 
 class RewriteMostSpecificCommonBase(TypeRewriter):
     """
-    Relaces a union of classes by the most specific
+    Relace a union of classes by the most specific
     common base of its members (while avoiding multiple
-    inheritance).
+    inheritance), i.e.,
+
+    Union[Derived1, Derived2] -> Base
     """
 
     def _compute_bases(self, klass):
         """
-        Returns list of bases of a given class,
+        Return list of bases of a given class,
         going from general (i.e., closer to object)
-        to specific (i.e., closer to klass).
-        The list ends with the klass itself, its
+        to specific (i.e., closer to class).
+        The list ends with the class itself, its
         first element is the most general base of
-        the klass up to (but excluding) any
-        base that has multiple inheritance.
+        the class up to (but excluding) any
+        base class having multiple inheritance
+        or the object class itself.
         """
         bases = []
 
@@ -535,6 +538,11 @@ class RewriteMostSpecificCommonBase(TypeRewriter):
         return bases[::-1]
 
     def _merge_common_bases(self, first_bases, second_bases):
+        """
+        Return list of bases common to both* classes,
+        going from general (i.e., closer to object)
+        to specific (i.e., closer to both classes).
+        """
         merged_bases = []
 
         # Only process up to shorter of the lists
@@ -547,6 +555,10 @@ class RewriteMostSpecificCommonBase(TypeRewriter):
         return merged_bases
 
     def rewrite_Union(self, union):
+        """
+        Rewrite the union if possible, if no meaningful rewrite is possible,
+        return the original union.
+        """
         klasses = union.__args__
 
         all_bases = []

--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -549,13 +549,13 @@ class RewriteMostSpecificCommonBase(TypeRewriter):
     def rewrite_Union(self, union):
         klasses = union.__args__
 
-        bases = []
+        all_bases = []
 
         for klass in klasses:
-            base = self._compute_bases(klass)
-            bases.append(base)
+            klass_bases = self._compute_bases(klass)
+            all_bases.append(klass_bases)
 
-        common_bases = functools.reduce(self._merge_common_bases, bases)
+        common_bases = functools.reduce(self._merge_common_bases, all_bases)
 
         if common_bases:
             return common_bases[-1]


### PR DESCRIPTION
This is an attempted fix for #298: It replaces a union of types by the most common (i.e., most specific) base of all types in the union. 