### PR TITLE
Improve database structure

### DIFF
--- a/monkeytype/db/sqlite.py
+++ b/monkeytype/db/sqlite.py
@@ -3,10 +3,10 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import datetime
+
 import logging
 import sqlite3
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, cast
 
 from monkeytype.db.base import CallTraceStore, CallTraceThunk
 from monkeytype.encoding import CallTraceRow, serialize_traces
@@ -15,115 +15,248 @@ from monkeytype.tracing import CallTrace
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_TABLE = "monkeytype_call_traces"
-
-
-def create_call_trace_table(
-    conn: sqlite3.Connection, table: str = DEFAULT_TABLE
-) -> None:
+def create_call_trace_tables(conn: sqlite3.Connection) -> None:
     queries = [
-        """
-        CREATE TABLE IF NOT EXISTS {table} (
-          created_at  TEXT,
-          module      TEXT,
-          qualname    TEXT,
-          arg_types   TEXT,
-          return_type TEXT,
-          yield_type  TEXT);
-        """,
-        """
-        -- This index speeds up lookups of call traces of a single module
-        -- (see `make_query()`).
-        CREATE INDEX IF NOT EXISTS {table}_module ON {table} (module);
-        """,
+        """CREATE TABLE IF NOT EXISTS monkeytype_signatures (
+            id INTEGER PRIMARY KEY,
+            arg_types VARCHAR,
+            return_type VARCHAR,
+            yield_type VARCHAR
+        )""",
+        """CREATE TABLE IF NOT EXISTS monkeytype_modules (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR NOT NULL,
+            UNIQUE (name)
+        )""",
+        """CREATE TABLE IF NOT EXISTS monkeytype_functions (
+            id INTEGER PRIMARY KEY,
+            qualname VARCHAR NOT NULL,
+            module_id INTEGER,
+            FOREIGN KEY(module_id) REFERENCES monkeytype_modules (id),
+            UNIQUE (qualname)
+        )""",
+        """CREATE TABLE IF NOT EXISTS monkeytype_functions_signatures (
+            function_id INTEGER,
+            signature_id INTEGER,
+            PRIMARY KEY (function_id, signature_id),
+            FOREIGN KEY(function_id) REFERENCES monkeytype_functions (id),
+            FOREIGN KEY(signature_id) REFERENCES monkeytype_signatures (id)
+        )""",
     ]
 
     with conn:
         for query in queries:
-            conn.execute(query.format(table=table))
-
-
-QueryValue = Union[str, int]
-ParameterizedQuery = Tuple[str, List[QueryValue]]
-
-
-def make_query(
-    table: str, module: str, qualname: Optional[str], limit: int
-) -> ParameterizedQuery:
-    raw_query = """
-    SELECT
-        module, qualname, arg_types, return_type, yield_type
-    FROM {table}
-    WHERE
-        module == ?
-    """.format(
-        table=table
-    )
-    values: List[QueryValue] = [module]
-    if qualname is not None:
-        raw_query += " AND qualname LIKE ? || '%'"
-        values.append(qualname)
-    raw_query += """
-    GROUP BY
-        module, qualname, arg_types, return_type, yield_type
-    ORDER BY date(created_at) DESC
-    LIMIT ?
-    """
-    values.append(limit)
-    return raw_query, values
+            conn.execute(query)
 
 
 class SQLiteStore(CallTraceStore):
-    def __init__(self, conn: sqlite3.Connection, table: str = DEFAULT_TABLE) -> None:
+    def __init__(self, conn: sqlite3.Connection) -> None:
         self.conn = conn
-        self.table = table
 
     @classmethod
     def make_store(cls, connection_string: str) -> "CallTraceStore":
         conn = sqlite3.connect(connection_string)
-        create_call_trace_table(conn)
+        create_call_trace_tables(conn)
         return cls(conn)
 
-    def add(self, traces: Iterable[CallTrace]) -> None:
+    def get_signature(
+        self, arg_types: str, return_type: Optional[str], yield_type: Optional[str]
+    ) -> Optional[int]:
+        cur = self.conn.cursor()
+
         values = []
-        for row in serialize_traces(traces):
-            values.append(
-                (
-                    datetime.datetime.now(),
-                    row.module,
-                    row.qualname,
-                    row.arg_types,
-                    row.return_type,
-                    row.yield_type,
-                )
-            )
+        cons = []
+
+        def add_value(name: str, value: Optional[str]) -> None:
+            if value is None:
+                cons.append(f"({name} IS NULL)")
+            else:
+                cons.append(f"({name} == (?))")
+                values.append(value)
+
+        add_value("arg_types", arg_types)
+        add_value("return_type", return_type)
+        add_value("yield_type", yield_type)
+
+        all_cons = " AND ".join(cons)
+
+        query = f"""
+        SELECT id FROM monkeytype_signatures
+        WHERE {all_cons}
+        """
+
+        cur.execute(query, values)
+        row = cur.fetchone()
+
+        if row:
+            return cast(int, row[0])
+
+        return None
+
+    def get_or_add_signature(
+        self, arg_types: str, return_type: Optional[str], yield_type: Optional[str]
+    ) -> int:
+        signature = self.get_signature(arg_types, return_type, yield_type)
+
+        if signature is not None:
+            return signature
+
+        print(f"Adding signature: {arg_types}, {return_type}, {yield_type}")
+
+        cur = self.conn.cursor()
+
+        query = "INSERT INTO monkeytype_signatures(arg_types, return_type, yield_type) VALUES(?, ?, ?) RETURNING id"
+
+        values = [arg_types, return_type, yield_type]
+
+        cur.execute(query, values)
+
+        row = cur.fetchone()
+        return cast(int, row[0])
+
+    def get_module(self, qualname: str) -> Optional[int]:
+        cur = self.conn.cursor()
+
+        query = "SELECT id FROM monkeytype_modules WHERE name == ?"
+
+        cur.execute(query, [qualname])
+
+        row = cur.fetchone()
+
+        if row:
+            return cast(int, row[0])
+
+        return None
+
+    def get_or_add_module(self, name: str) -> int:
+        module = self.get_module(name)
+
+        if module is not None:
+            return module
+
+        cur = self.conn.cursor()
+        query = "INSERT INTO monkeytype_modules(name) VALUES (?) RETURNING id"
+        cur.execute(query, [name])
+
+        row = cur.fetchone()
+        return cast(int, row[0])
+
+    def get_function(self, qualname: str) -> Optional[int]:
+        cur = self.conn.cursor()
+
+        query = "SELECT id FROM monkeytype_functions WHERE qualname == (?)"
+
+        cur.execute(query, [qualname])
+
+        row = cur.fetchone()
+
+        if row:
+            return cast(int, row[0])
+
+        return None
+
+    def get_or_add_function(self, trace: CallTraceRow) -> int:
+        func = self.get_function(trace.qualname)
+
+        if func is not None:
+            return func
+
+        module = self.get_or_add_module(trace.module)
+
+        # assert module is not None
+
+        cur = self.conn.cursor()
+
+        query = "INSERT INTO monkeytype_functions(qualname, module_id) VALUES(?, ?) RETURNING id"
+
+        values = [trace.qualname, module]
+
+        cur.execute(query, values)
+
+        row = cur.fetchone()
+        func = cast(int, row[0])
+
+        signature = self.get_or_add_signature(
+            trace.arg_types, trace.return_type, trace.yield_type
+        )
+
+        self.add_signature_to_function(func, signature)
+
+        return func
+
+    def add_signature_to_function(self, function: int, signature: int) -> None:
+        cur = self.conn.cursor()
+
+        query = """
+        INSERT INTO monkeytype_functions_signatures(function_id, signature_id) VALUES(?, ?)
+        ON CONFLICT(function_id, signature_id) DO NOTHING
+        """
+
+        values = [function, signature]
+
+        cur.execute(query, values)
+
+    def add_trace(self, trace: CallTraceRow) -> None:
+        func = self.get_or_add_function(trace)
+
+        arg_types = trace.arg_types
+        return_type = trace.return_type
+        yield_type = trace.yield_type
+
+        signature = self.get_or_add_signature(arg_types, return_type, yield_type)
+
+        self.add_signature_to_function(func, signature)
+
+    def add(self, traces: Iterable[CallTrace]) -> None:
         with self.conn:
-            self.conn.executemany(
-                "INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?)".format(
-                    table=self.table
-                ),
-                values,
-            )
+            for trace in serialize_traces(traces):
+                self.add_trace(trace)
 
     def filter(
-        self, module: str, qualname_prefix: Optional[str] = None, limit: int = 2000
+        self, name: str, qualname_prefix: Optional[str] = None, limit: int = 2000
     ) -> List[CallTraceThunk]:
-        sql_query, values = make_query(self.table, module, qualname_prefix, limit)
-        with self.conn:
-            cur = self.conn.cursor()
-            cur.execute(sql_query, values)
-            return [CallTraceRow(*row) for row in cur.fetchall()]
+        cur = self.conn.cursor()
+
+        values: List[Any] = [name]
+
+        qualname_cond = ""
+
+        if qualname_prefix is not None:
+            qualname_cond = "AND func.qualname LIKE (?) || '%'"
+            values.append(qualname_prefix)
+
+        query = f"""
+        SELECT func.qualname, module.name, sig.arg_types, sig.return_type, sig.yield_type
+        FROM monkeytype_functions func
+        JOIN monkeytype_functions_signatures func_sig ON func.id = func_sig.function_id
+        JOIN monkeytype_signatures sig ON func_sig.signature_id = sig.id
+        JOIN monkeytype_modules module ON func.module_id = module.id
+        WHERE module.name == (?)
+        {qualname_cond}
+        LIMIT (?)
+        """
+
+        values.append(limit)
+
+        cur.execute(query, values)
+
+        rows: List[CallTraceThunk] = []
+
+        for row in cur.fetchall():
+            (qualname, module, arg_types, return_type, yield_type) = row
+            trace_row = CallTraceRow(
+                module, qualname, arg_types, return_type, yield_type
+            )
+            rows.append(trace_row)
+
+        return rows
 
     def list_modules(self) -> List[str]:
-        with self.conn:
-            cur = self.conn.cursor()
-            cur.execute(
-                """
-                        SELECT module FROM {table}
-                        GROUP BY module
-                        ORDER BY date(created_at) DESC
-                        """.format(
-                    table=self.table
-                )
-            )
-            return [row[0] for row in cur.fetchall() if row[0]]
+        cur = self.conn.cursor()
+
+        query = "SELECT name FROM monkeytype_modules"
+
+        cur.execute(query)
+        rows = cur.fetchall()
+
+        return [row[0] for row in rows]

--- a/tests/db/test_base.py
+++ b/tests/db/test_base.py
@@ -8,7 +8,7 @@ import sqlite3
 
 from monkeytype.db.base import CallTraceStoreLogger
 from monkeytype.db.sqlite import (
-    create_call_trace_table,
+    create_call_trace_tables,
     SQLiteStore,
 )
 from monkeytype.tracing import trace_calls
@@ -26,7 +26,7 @@ def main_func(a, b):
 @pytest.fixture
 def logger() -> CallTraceStoreLogger:
     conn = sqlite3.connect(':memory:')
-    create_call_trace_table(conn)
+    create_call_trace_tables(conn)
     return CallTraceStoreLogger(SQLiteStore(conn))
 
 

--- a/tests/db/test_sqlite.py
+++ b/tests/db/test_sqlite.py
@@ -7,7 +7,7 @@ import pytest
 import sqlite3
 
 from monkeytype.db.sqlite import (
-    create_call_trace_table,
+    create_call_trace_tables,
     SQLiteStore,
     )
 from monkeytype.tracing import CallTrace
@@ -24,7 +24,7 @@ def func2(a, b):
 @pytest.fixture
 def store() -> SQLiteStore:
     conn = sqlite3.connect(':memory:')
-    create_call_trace_table(conn)
+    create_call_trace_tables(conn)
     return SQLiteStore(conn)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from libcst.codemod.visitors import ImportItem
 from monkeytype import cli
 from monkeytype.config import DefaultConfig
 from monkeytype.db.sqlite import (
-    create_call_trace_table,
+    create_call_trace_tables,
     SQLiteStore,
     )
 from monkeytype.exceptions import MonkeyTypeError
@@ -75,7 +75,7 @@ class LoudContextConfig(DefaultConfig):
 def store_data():
     with tempfile.NamedTemporaryFile(prefix='monkeytype_tests') as db_file:
         conn = sqlite3.connect(db_file.name)
-        create_call_trace_table(conn)
+        create_call_trace_tables(conn)
         with mock.patch.dict(os.environ, {DefaultConfig.DB_PATH_VAR: db_file.name}):
             yield SQLiteStore(conn), db_file
 


### PR DESCRIPTION
I noticed a problem with the database created by MonkeyType during the tracing process. Namely, the database is very flat, only consisting of a single table:

```sql
        CREATE TABLE IF NOT EXISTS monkeytype_call_traces (
          created_at  TEXT,
          module      TEXT,
          qualname    TEXT,
          arg_types   TEXT,
          return_type TEXT,
          yield_type  TEXT);
```

First of all, the `created_at` column is redundant and never used. I suspect that this was put into the database in order to ensure uniqueness of columns (which is ensured anyways due to `rowid`s).

Most problematically, no deduplication is being done, new records are just entered into the database one after another. As a consequence the database becomes incredibly large, even when no new and information is added. For instance, when I trace the call `my_method(value=1)` one million times, the database contains one million records, where a single one would do. This is particularly bothersome when monkeytype is used within pytest, where parameterized tests quickly run into the thousands or millions. I was trying to type out a larger package and ended up with a file with a size of >= 100GB.

The new structure splits the database into multiple tables for signatures, modules, and functions, where signatures are deduplicated. In my example, this reduced the database size to below 1MB.