### PR TITLE
Support for instance objects

### DIFF
--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -24,6 +24,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    Self
 )
 
 from mypy_extensions import TypedDict
@@ -243,6 +244,7 @@ def get_type(obj, max_typed_dict_size):
 
 
 NoneType = type(None)
+SelfType = Self
 NotImplementedType = type(NotImplemented)
 mappingproxy = type(range.__dict__)
 


### PR DESCRIPTION
Fixes #337 

[WIP]

Support for methods that return instance objects but are untyped or typed with the Any type.

```python
class Some:
   def add(self, attr): 
      self.acc += attr
      return self
```