### PR TITLE
Add Swordk keymap

### DIFF
--- a/monkeytype/Swordk_map.py
+++ b/monkeytype/Swordk_map.py
@@ -1,0 +1,42 @@
+# Swordk_map.py
+from monkeytype.config import DefaultConfig
+
+class SwordkKeymap(DefaultConfig):
+    def get_keymap(self):
+        return {
+            'q': 's',
+            'w': 'w',
+            'e': 'o',
+            'r': 'r',
+            't': 'd',
+            'y': 'k',
+            'u': 'y',
+            'i': 'u',
+            'o': 'p',
+            'p': 'q',
+            '[': '/',
+            ']': "'",
+
+            'a': 't',
+            's': 'h',
+            'd': 'e',
+            'f': 'a',
+            'g': 'f',
+            'h': ',',
+            'j': 'l',
+            'k': 'g',
+            'l': 'i',
+            ';': 'n',
+            "'": ';',
+
+            'z': 'm',
+            'x': 'x',
+            'c': 'c',
+            'v': 'v',
+            'b': 'b',
+            'n': 'j',
+            'm': '.',
+            ',': 'z',
+            '.': '[',
+            '/': ']'
+        }


### PR DESCRIPTION

![Swordkmap](https://github.com/user-attachments/assets/a1eb823c-bc89-4c5b-8d5b-019b7e1595ae)

Technical : Added the Swordk_map.py file which contains custom key mappings for the MonkeyType configuration. This setup reassigns keys according to the specified layout so you can practice with it, if you wish.

What it is : "Swordk" is a prototypical keymap loosely based on the philosophies of Qwerty and Colemak designed through the process of trial and error live testing with the goal of being an easier transition from Qwerty.