### PR TITLE
upgrade upload artifact to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         pipenv run pytest
 
     - name: Upload htmldoc
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: htmlcov
         path: htmlcov
@@ -72,7 +72,7 @@ jobs:
         pipenv run make html
 
     - name: Upload doc
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: doc
         path: doc/_build/html


### PR DESCRIPTION
acording to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ (and our failing test) v3 is not longer supported... upgrading to v4