### PR TITLE
Add a CLI --version flag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 main
 ----
 
+* Add a ``--version`` flag to the CLI. Thanks DeoJin.
+
 * Add ``RewriteMostSpecificCommonBase`` type rewriter to replace union of derived classes with common
   base class (not enabled by default.) Merge of #311, fixes #298. Thanks Christoph Hansknecht.
 

--- a/monkeytype/__init__.py
+++ b/monkeytype/__init__.py
@@ -8,6 +8,8 @@ from typing import ContextManager, Optional
 from monkeytype.config import Config, get_default_config
 from monkeytype.tracing import trace_calls
 
+__version__ = "23.3.1.dev1"
+
 
 def trace(config: Optional[Config] = None) -> ContextManager[None]:
     """Context manager to trace and log all calls.

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -23,7 +23,7 @@ from libcst.codemod.visitors import (
     ImportItem,
 )
 
-from monkeytype import trace
+from monkeytype import __version__, trace
 from monkeytype.config import Config
 from monkeytype.exceptions import MonkeyTypeError
 from monkeytype.stubs import (
@@ -330,6 +330,11 @@ def main(argv: List[str], stdout: IO[str], stderr: IO[str]) -> int:
             " (default: monkeytype_config:CONFIG if it exists, "
             "else monkeytype.config:DefaultConfig())"
         ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"MonkeyType {__version__}",
     )
 
     subparsers = parser.add_subparsers(title="commands", dest="command")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,6 +102,15 @@ def stderr():
     return io.StringIO()
 
 
+def test_version_flag(capsys, stdout, stderr):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(['--version'], stdout, stderr)
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out == 'MonkeyType 23.3.1.dev1\n'
+    assert captured.err == ''
+
+
 def test_generate_stub(store, db_file, stdout, stderr):
     traces = [
         CallTrace(func, {'a': int, 'b': str}, NoneType),


### PR DESCRIPTION
## Summary
- add a top-level \\--version\\ argparse flag that prints the installed MonkeyType version
- expose \\monkeytype.__version__\\ so the CLI can report a consistent package version
- add a focused CLI test and changelog entry

## Validation
- \\uv run --python .venv\\Scripts\\python.exe pytest tests/test_cli.py -q -k version_flag\\
- \\uv run --python .venv\\Scripts\\python.exe monkeytype --version\\

Fixes #354