### PR TITLE
fix: refresh tox config for current pipenv tooling

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,20 @@
 [tox]
 envlist =
-  py38
   py39
   py310
   py311
 
 [testenv]
 deps =
-  pipenv==2022.11.30
+  pipenv>=2025.0.3
+
+allowlist_externals =
+  pipenv
 
 commands =
   pipenv sync -d
-  flake8
-  black --check --diff monkeytype
-  isort --check --diff monkeytype
-  mypy monkeytype
-  pytest
+  pipenv run ruff check monkeytype
+  pipenv run ruff format --check --diff monkeytype
+  pipenv run isort --check --diff monkeytype
+  pipenv run mypy monkeytype
+  pipenv run pytest


### PR DESCRIPTION
## Summary

Refresh the tox config so it works with the repository's current Pipfile.lock and newer pipenv releases.

## Changes

- require a current pipenv version compatible with newer Python releases
- allow calling pipenv from tox explicitly
- run lint/test commands through pipenv run so tox uses tools from the locked environment
- switch the lint/format commands from missing lake8/lack entries to the locked uff tooling already present in Pipfile.lock
- drop py38 from the tox env list to match the project's current supported Python baseline

## Testing

- uv run --python 3.11 --with tox tox -e py311
  - passed pipenv sync -d, uff check, uff format --check, and isort --check
  - then stopped at a pre-existing unrelated mypy configuration error from setup.cfg (python_version = 3.7 is not supported)

Fixes #355