### PR TITLE
Add a --version flag to the CLI

### DIFF
--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import argparse
 import collections
+import configparser
 import difflib
 import importlib
 import inspect
@@ -14,6 +15,11 @@ import runpy
 import sys
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, List, Optional, Tuple
+
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError, version
 
 from libcst import Module, parse_module
 from libcst.codemod import CodemodContext
@@ -293,9 +299,25 @@ def update_args_from_config(args: argparse.Namespace) -> None:
         args.limit = args.config.query_limit()
 
 
+def get_version_string() -> str:
+    try:
+        return version("MonkeyType")
+    except PackageNotFoundError:
+        config = configparser.ConfigParser()
+        setup_cfg = Path(__file__).resolve().parent.parent / "setup.cfg"
+        if config.read(setup_cfg):
+            return config["metadata"].get("version", "unknown")
+        return "unknown"
+
+
 def main(argv: List[str], stdout: IO[str], stderr: IO[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Generate and apply stub files from collected type information.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"MonkeyType {get_version_string()}",
     )
     parser.add_argument(
         "--disable-type-rewriting",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,25 @@ def test_display_list_of_modules_no_modules(store, db_file, stdout, stderr):
     assert ret == 0
 
 
+def test_version_option(capsys, stdout, stderr):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(['--version'], stdout, stderr)
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 0
+    assert captured.out.startswith('MonkeyType ')
+    assert captured.err == ''
+
+
+def test_version_option_falls_back_to_unknown(capsys, stdout, stderr):
+    with mock.patch.object(cli, 'get_version_string', return_value='unknown'):
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(['--version'], stdout, stderr)
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 0
+    assert captured.out == 'MonkeyType unknown\n'
+    assert captured.err == ''
+
+
 def test_display_sample_count(stderr):
     traces = [
         CallTrace(func, {'a': int, 'b': str}, NoneType),


### PR DESCRIPTION
## Summary
- add a top-level `--version` flag to the `monkeytype` CLI
- resolve the version from installed package metadata, with a source-tree fallback to `setup.cfg`
- add focused CLI tests for both the normal and fallback version output paths

Closes #354

## Validation
- `uv run --python 3.11 --with pytest --with libcst --with mypy_extensions --with importlib_metadata pytest tests/test_cli.py -k version_option`
- `uv run --python 3.11 --with libcst --with mypy_extensions --with importlib_metadata python -m monkeytype --version`
