### PR TITLE
fix: render named TypedDict annotations

### DIFF
--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -320,6 +320,9 @@ class RenderAnnotation(GenericTypeRewriter[str]):
             f" but was called with name={name}, annotations={annotations}, total={total}."
         )
 
+    def rewrite_TypedDict(self, typed_dict: type) -> str:
+        return self.generic_rewrite(typed_dict)
+
     def generic_rewrite(self, typ: Any) -> str:
         if hasattr(typ, "__supertype__"):
             rendered = str(typ.__name__)

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -212,6 +212,12 @@ class TestRenderAnnotation:
     def test_render_annotation(self, annotation, expected):
         assert render_annotation(annotation) == expected
 
+    def test_render_annotation_builtin_typed_dict(self):
+        class RunInfo(TypedDict):
+            revision: str
+
+        assert render_annotation(RunInfo) == f"{RunInfo.__module__}.{RunInfo.__qualname__}"
+
 
 class TestFunctionStub:
     def test_classmethod(self):


### PR DESCRIPTION
## Summary
Fix a crash when rendering annotations for named mypy_extensions.TypedDict types.

## Changes
- treat named TypedDict annotations like other named user-defined types during annotation rendering
- add a regression test covering a real named TypedDict case

## Testing
- uv run --python .venv pytest tests/test_stubs.py -k RenderAnnotation
- reproduced the original failure with a small ender_annotation(RunInfo) script before the fix

Fixes #342