### PR TITLE
tox: update pipenv and run checks through pipenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,12 @@ envlist =
 
 [testenv]
 deps =
-  pipenv==2022.11.30
+  pipenv>=2025.0.3
 
 commands =
   pipenv sync -d
-  flake8
-  black --check --diff monkeytype
-  isort --check --diff monkeytype
-  mypy monkeytype
-  pytest
+  pipenv run flake8
+  pipenv run black --check --diff monkeytype
+  pipenv run isort --check --diff monkeytype
+  pipenv run mypy monkeytype
+  pipenv run pytest


### PR DESCRIPTION
## Summary
- update the pinned `pipenv` version in `tox.ini` to a modern release compatible with newer Python versions
- run flake8, black, isort, mypy, and pytest via `pipenv run` so tox executes the tools from the Pipenv-managed environment
- keep the change narrowly scoped to the outdated tox configuration reported in #355

Closes #355.

## Validation
- `git diff --check`
- manual inspection of `tox.ini`

Note: this host does not currently have a local Python runtime available, so I could not execute the full tox or pytest workflow here.