### PR TITLE
Replace deprecated mypy_extensions TypedDict

### DIFF
--- a/monkeytype/compat.py
+++ b/monkeytype/compat.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Any, ForwardRef, Union, _GenericAlias  # type: ignore[attr-defined]
 
-from mypy_extensions import _TypedDictMeta  # type: ignore[attr-defined]
+from typing_extensions import _TypedDictMeta
 
 try:
     from django.utils.functional import cached_property as cp
@@ -102,3 +102,4 @@ def types_equal(typ: type, other_type: type) -> bool:
 # HACK: MonkeyType monkey-patches _TypedDictMeta!
 # We need this to compare TypedDicts recursively.
 _TypedDictMeta.__eq__ = __are_typed_dict_types_equal
+

--- a/monkeytype/encoding.py
+++ b/monkeytype/encoding.py
@@ -7,7 +7,7 @@ import json
 import logging
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
 
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 from monkeytype.compat import is_any, is_generic, is_union, qualname_of_generic
 from monkeytype.db.base import CallTraceThunk
@@ -235,3 +235,4 @@ def serialize_traces(traces: Iterable[CallTrace]) -> Iterable[CallTraceRow]:
             yield CallTraceRow.from_trace(trace)
         except Exception:
             logger.exception("Failed to serialize trace")
+

--- a/monkeytype/stubs.py
+++ b/monkeytype/stubs.py
@@ -855,7 +855,7 @@ def build_module_stubs(entries: Iterable[FunctionDefinition]) -> Dict[str, Modul
         imports = get_imports_for_signature(entry.signature)
         # Import TypedDict, if needed.
         if entry.typed_dict_class_stubs:
-            imports["mypy_extensions"].add("TypedDict")
+            imports["typing_extensions"].add("TypedDict")
         func_stub = FunctionStub(
             name, entry.signature, entry.kind, list(imports.keys()), entry.is_async
         )

--- a/monkeytype/typing.py
+++ b/monkeytype/typing.py
@@ -26,7 +26,7 @@ from typing import (
     Union,
 )
 
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 from monkeytype.compat import (
     is_any,
@@ -574,3 +574,4 @@ DEFAULT_REWRITER = ChainedRewriter(
         RewriteGenerator(),
     )
 )
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 include-package-data = True
 python_requires = >= 3.7
 install_requires =
-    mypy_extensions
+    typing_extensions
     libcst>=0.4.4
 
 [options.packages.find]
@@ -88,3 +88,4 @@ line-length = 80
 
 [tool:pytest]
 addopts = --tb short
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -369,8 +369,8 @@ def test_apply_stub_using_libcst():
           return None
     """
     stub = """
-        from mypy_extensions import TypedDict
         from typing import Union
+        from typing_extensions import TypedDict
         def my_test_function(a: int, b: str) -> bool: ...
 
         def has_return_type(a: int, b: int) -> bool: ...
@@ -386,8 +386,8 @@ def test_apply_stub_using_libcst():
           year: int
     """
     expected = """
-        from mypy_extensions import TypedDict
         from typing import Union
+        from typing_extensions import TypedDict
 
         class Foo: ...
 
@@ -518,3 +518,4 @@ def test_get_newly_imported_items():
         parse_module(textwrap.dedent(stub)),
         parse_module(textwrap.dedent(source)),
     ))
+

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -26,7 +26,7 @@ from monkeytype.encoding import (
     type_to_json,
     serialize_traces,
 )
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 from monkeytype.exceptions import InvalidTypeError
 from monkeytype.tracing import CallTrace
 from monkeytype.typing import DUMMY_TYPED_DICT_NAME, NoneType, NotImplementedType, mappingproxy
@@ -275,3 +275,4 @@ class TestSerializeTraces:
         ]
         assert rows == expected
         assert [r.msg for r in caplog.records] == ["Failed to serialize trace"]
+

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -53,7 +53,7 @@ from monkeytype.stubs import (
 )
 from monkeytype.tracing import CallTrace
 from monkeytype.typing import NoneType, make_typed_dict
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 from .util import Dummy
 
 UserId = NewType('UserId', int)
@@ -501,7 +501,7 @@ class TestReplaceTypedDictsWithStubs:
 
 
 typed_dict_import_map = ImportMap()
-typed_dict_import_map['mypy_extensions'] = {'TypedDict'}
+typed_dict_import_map['typing_extensions'] = {'TypedDict'}
 module_stub_for_method_with_typed_dict = {
     'tests.util': ModuleStub(
         function_stubs=(),
@@ -526,7 +526,7 @@ module_stub_for_method_with_typed_dict = {
                             return_annotation=make_forward_ref('DummyAnInstanceMethodTypedDict__RENAME_ME__'),
                         ),
                         kind=FunctionKind.INSTANCE,
-                        strip_modules=['mypy_extensions'],
+                        strip_modules=['typing_extensions'],
                         is_async=False,
                     ),
                 ],
@@ -664,7 +664,7 @@ class TestModuleStub:
         )
         entries = [function]
         expected = '\n'.join([
-            'from mypy_extensions import TypedDict',
+            'from typing_extensions import TypedDict',
             '',
             '',
             'class FooTypedDict__RENAME_ME__(TypedDict):',
@@ -696,7 +696,7 @@ class TestModuleStub:
         )
         entries = [function]
         expected = '\n'.join([
-            'from mypy_extensions import TypedDict',
+            'from typing_extensions import TypedDict',
             '',
             '',
             'class DummyAnInstanceMethodTypedDict__RENAME_ME__(TypedDict):',
@@ -724,8 +724,8 @@ class TestModuleStub:
         )
         entries = [function]
         expected = '\n'.join([
-            'from mypy_extensions import TypedDict',
             'from typing import Generator',
+            'from typing_extensions import TypedDict',
             '',
             '',
             'class DummyAnInstanceMethodYieldTypedDict__RENAME_ME__(TypedDict):',
@@ -756,8 +756,8 @@ class TestModuleStub:
         )
         entries = [function]
         expected = '\n'.join([
-            'from mypy_extensions import TypedDict',
             'from typing import List',
+            'from typing_extensions import TypedDict',
             '',
             '',
             'class FooTypedDict__RENAME_ME__(TypedDict):',
@@ -782,7 +782,7 @@ class TestModuleStub:
         )
         entries = [function]
         expected = '\n'.join([
-            'from mypy_extensions import TypedDict',
+            'from typing_extensions import TypedDict',
             '',
             '',
             'class FooTypedDict__RENAME_ME__(TypedDict):',
@@ -1301,3 +1301,4 @@ class TestGetImportsForSignature:
         stub = FunctionStub('test', inspect.signature(default_none_parameter), FunctionKind.MODULE)
         expected = {'typing': {'Optional'}}
         assert get_imports_for_signature(stub.signature) == expected
+

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -43,7 +43,7 @@ from monkeytype.typing import (
     DUMMY_TYPED_DICT_NAME,
 )
 
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 from .util import Dummy
 
@@ -909,3 +909,4 @@ class TestRewriteAnonymousTypedDictToDict:
     def test_rewrite(self, typ, expected):
         rewritten = RewriteAnonymousTypedDictToDict().rewrite(typ)
         assert rewritten == expected
+


### PR DESCRIPTION
## Summary
- replace deprecated `mypy_extensions` TypedDict imports with `typing_extensions`
- update the generated TypedDict import path and the related test expectations
- switch the package dependency from `mypy_extensions` to `typing_extensions`

## Testing
- `uv run --with pytest --with typing_extensions --with libcst python -c "import monkeytype.compat, monkeytype.encoding, monkeytype.typing, monkeytype.stubs; print('import-ok')"`
- `uv run --with pytest --with typing_extensions --with libcst pytest tests/test_encoding.py tests/test_typing.py tests/test_stubs.py -q`
- `uv run --with pytest --with typing_extensions --with libcst pytest tests/test_cli.py -q -k "apply_stub_using_libcst or get_newly_imported_items"`

Fixes #357
