### PR TITLE
Add a CLI version flag

### DIFF
--- a/monkeytype/__init__.py
+++ b/monkeytype/__init__.py
@@ -3,10 +3,33 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from configparser import ConfigParser
+from pathlib import Path
 from typing import ContextManager, Optional
+
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # pragma: no cover
+    from importlib_metadata import PackageNotFoundError, version
 
 from monkeytype.config import Config, get_default_config
 from monkeytype.tracing import trace_calls
+
+
+PACKAGE_NAME = "MonkeyType"
+
+
+def get_version() -> str:
+    try:
+        return version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        setup_cfg = Path(__file__).resolve().parent.parent / "setup.cfg"
+        parser = ConfigParser()
+        parser.read(setup_cfg)
+        return parser["metadata"]["version"]
+
+
+__version__ = get_version()
 
 
 def trace(config: Optional[Config] = None) -> ContextManager[None]:

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -23,7 +23,7 @@ from libcst.codemod.visitors import (
     ImportItem,
 )
 
-from monkeytype import trace
+from monkeytype import __version__, trace
 from monkeytype.config import Config
 from monkeytype.exceptions import MonkeyTypeError
 from monkeytype.stubs import (
@@ -296,6 +296,11 @@ def update_args_from_config(args: argparse.Namespace) -> None:
 def main(argv: List[str], stdout: IO[str], stderr: IO[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Generate and apply stub files from collected type information.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parser.add_argument(
         "--disable-type-rewriting",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,6 +203,16 @@ def test_no_traces(store, db_file, stdout, stderr, arg, error):
     assert ret == 0
 
 
+def test_version_flag(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(['--version'], io.StringIO(), io.StringIO())
+
+    out, err = capsys.readouterr()
+    assert out.endswith(f" {cli.__version__}\n")
+    assert err == ""
+    assert exc_info.value.code == 0
+
+
 def test_display_list_of_modules(store, db_file, stdout, stderr):
     traces = [
         CallTrace(func, {'a': int, 'b': str}, NoneType),


### PR DESCRIPTION
## Summary
- add a `--version` flag to the MonkeyType CLI
- expose `monkeytype.__version__`, resolving from package metadata with a source-tree fallback
- add a focused CLI test for the new flag

## Validation
- `uv run --with pytest --with libcst --with mypy_extensions pytest tests/test_cli.py -q -k version_flag`
- `uv run --with libcst --with mypy_extensions python -m monkeytype --version`