### PR TITLE
feat: add --version CLI option

### DIFF
--- a/monkeytype/__init__.py
+++ b/monkeytype/__init__.py
@@ -3,10 +3,16 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from importlib.metadata import PackageNotFoundError, version
 from typing import ContextManager, Optional
 
 from monkeytype.config import Config, get_default_config
 from monkeytype.tracing import trace_calls
+
+try:
+    __version__ = version("MonkeyType")
+except PackageNotFoundError:
+    __version__ = "0+unknown"
 
 
 def trace(config: Optional[Config] = None) -> ContextManager[None]:

--- a/monkeytype/cli.py
+++ b/monkeytype/cli.py
@@ -23,7 +23,7 @@ from libcst.codemod.visitors import (
     ImportItem,
 )
 
-from monkeytype import trace
+from monkeytype import __version__, trace
 from monkeytype.config import Config
 from monkeytype.exceptions import MonkeyTypeError
 from monkeytype.stubs import (
@@ -330,6 +330,11 @@ def main(argv: List[str], stdout: IO[str], stderr: IO[str]) -> int:
             " (default: monkeytype_config:CONFIG if it exists, "
             "else monkeytype.config:DefaultConfig())"
         ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"MonkeyType {__version__}",
     )
 
     subparsers = parser.add_subparsers(title="commands", dest="command")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,6 +203,15 @@ def test_no_traces(store, db_file, stdout, stderr, arg, error):
     assert ret == 0
 
 
+def test_version_flag(stdout, stderr):
+    with mock.patch.object(sys, 'stdout', stdout):
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(['--version'], stdout, stderr)
+    assert excinfo.value.code == 0
+    assert stdout.getvalue().startswith('MonkeyType ')
+    assert stderr.getvalue() == ''
+
+
 def test_display_list_of_modules(store, db_file, stdout, stderr):
     traces = [
         CallTrace(func, {'a': int, 'b': str}, NoneType),


### PR DESCRIPTION
## Summary
- add a package-backed __version__ constant to MonkeyType
- expose --version on the CLI via argparse's built-in version action
- add a focused CLI test for the new flag

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_cli.py -k version_flag -q

Fixes #354